### PR TITLE
Implemented the steller wallet connector

### DIFF
--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -1,17 +1,26 @@
-import React, { createContext, useContext, useCallback, useEffect, useMemo, useState, ReactNode } from 'react';
+import React, { createContext, useContext, useCallback, useEffect, useMemo, useState, ReactNode, useRef } from 'react';
+import { StellarNetwork, NETWORK, HORIZON_URL } from '@/utils/networkConfig';
+
+type WalletType = 'freighter' | 'albedo';
 
 type WalletState = {
   address: string | null;
+  network: StellarNetwork;
+  balance: string | null;
   isConnecting: boolean;
   error: string | null;
+  walletType: WalletType | null;
 };
 
 interface WalletContextType {
   address: string | null;
+  network: StellarNetwork;
+  balance: string | null;
   isConnected: boolean;
   isConnecting: boolean;
   error: string | null;
-  connect: () => Promise<void>;
+  walletType: WalletType | null;
+  connect: (walletType: WalletType) => Promise<void>;
   disconnect: () => void;
 }
 
@@ -22,15 +31,111 @@ async function loadFreighter() {
   return mod;
 }
 
+async function loadAlbedo() {
+  const mod = await import('@albedo-link/intent');
+  return mod;
+}
+
+async function fetchBalance(address: string, network: StellarNetwork): Promise<string> {
+  try {
+    const horizonUrl = network === 'mainnet' 
+      ? 'https://horizon.stellar.org' 
+      : 'https://horizon-testnet.stellar.org';
+    
+    const response = await fetch(`${horizonUrl}/accounts/${address}`);
+    if (!response.ok) {
+      throw new Error('Failed to fetch account');
+    }
+    
+    const data = await response.json();
+    const xlmBalance = data.balances?.find((b: { asset_type: string; balance: string }) => b.asset_type === 'native');
+    return xlmBalance?.balance ?? '0';
+  } catch {
+    return '0';
+  }
+}
+
 export function WalletProvider({ children }: { children: ReactNode }) {
   const [state, setState] = useState<WalletState>({
     address: null,
+    network: NETWORK,
+    balance: null,
     isConnecting: false,
-    error: null
+    error: null,
+    walletType: null
   });
+
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const isConnected = useMemo(() => Boolean(state.address), [state.address]);
 
+  // Fetch balance when address changes
+  useEffect(() => {
+    if (!state.address) {
+      setState((s) => ({ ...s, balance: null }));
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      const balance = await fetchBalance(state.address!, state.network);
+      if (!cancelled) {
+        setState((s) => ({ ...s, balance }));
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [state.address, state.network]);
+
+  // Poll for account/network changes
+  useEffect(() => {
+    if (!state.address || !state.walletType) return;
+
+    const checkForChanges = async () => {
+      try {
+        if (state.walletType === 'freighter') {
+          const freighter = await loadFreighter();
+          const currentAddress = await freighter.getPublicKey();
+          const currentNetwork = await freighter.getNetwork();
+          
+          // Map Freighter network names to our StellarNetwork type
+          const networkMap: Record<string, StellarNetwork> = {
+            'PUBLIC': 'mainnet',
+            'TESTNET': 'testnet',
+            'FUTURENET': 'futurenet'
+          };
+          
+          const mappedNetwork = networkMap[currentNetwork] ?? 'testnet';
+          
+          if (currentAddress !== state.address || mappedNetwork !== state.network) {
+            setState((s) => ({
+              ...s,
+              address: currentAddress,
+              network: mappedNetwork
+            }));
+          }
+        } else if (state.walletType === 'albedo') {
+          // Albedo doesn't provide network info, so we use the configured network
+          // We can't poll for address changes with Albedo
+        }
+      } catch {
+        // Ignore polling errors
+      }
+    };
+
+    pollingRef.current = setInterval(checkForChanges, 5000);
+
+    return () => {
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current);
+        pollingRef.current = null;
+      }
+    };
+  }, [state.address, state.walletType, state.network]);
+
+  // Check for existing Freighter connection on mount
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -42,9 +147,23 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         const allowed = await freighter.isAllowed();
         if (!allowed) return;
         const address = await freighter.getPublicKey();
-        if (!cancelled) setState((s) => ({ ...s, address, error: null }));
+        const network = await freighter.getNetwork();
+        
+        const networkMap: Record<string, StellarNetwork> = {
+          'PUBLIC': 'mainnet',
+          'TESTNET': 'testnet',
+          'FUTURENET': 'futurenet'
+        };
+        
+        const mappedNetwork = networkMap[network] ?? 'testnet';
+        
+        if (!cancelled) {
+          setState((s) => ({ ...s, address, network: mappedNetwork, walletType: 'freighter', error: null }));
+        }
       } catch {
-        if (!cancelled) setState((s) => ({ ...s, address: null }));
+        if (!cancelled) {
+          setState((s) => ({ ...s, address: null, walletType: null }));
+        }
       }
     })();
 
@@ -53,36 +172,63 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     };
   }, []);
 
-  const connect = useCallback(async () => {
+  const connect = useCallback(async (walletType: WalletType) => {
     setState((s) => ({ ...s, isConnecting: true, error: null }));
     try {
       if (typeof window === 'undefined') throw new Error('Wallet is only available in the browser.');
-      const freighter = await loadFreighter();
-      const connected = await freighter.isConnected();
-      if (!connected) throw new Error('Freighter wallet not detected.');
-      await freighter.setAllowed();
-      const address = await freighter.getPublicKey();
-      setState({ address, isConnecting: false, error: null });
+      
+      if (walletType === 'freighter') {
+        const freighter = await loadFreighter();
+        const connected = await freighter.isConnected();
+        if (!connected) throw new Error('Freighter wallet not detected. Please install the Freighter extension.');
+        await freighter.setAllowed();
+        const address = await freighter.getPublicKey();
+        const network = await freighter.getNetwork();
+        
+        const networkMap: Record<string, StellarNetwork> = {
+          'PUBLIC': 'mainnet',
+          'TESTNET': 'testnet',
+          'FUTURENET': 'futurenet'
+        };
+        
+        const mappedNetwork = networkMap[network] ?? 'testnet';
+        
+        setState({ address, network: mappedNetwork, balance: null, isConnecting: false, error: null, walletType: 'freighter' });
+      } else if (walletType === 'albedo') {
+        const albedo = await loadAlbedo();
+        const result = await albedo.publicKey({});
+        const address = result.pubkey;
+        
+        // Albedo doesn't provide network info, use configured network
+        setState({ address, network: NETWORK, balance: null, isConnecting: false, error: null, walletType: 'albedo' });
+      }
     } catch (e) {
       const message = e instanceof Error ? e.message : 'Failed to connect wallet.';
-      setState((s) => ({ ...s, isConnecting: false, address: null, error: message }));
+      setState((s) => ({ ...s, isConnecting: false, address: null, error: message, walletType: null }));
     }
   }, []);
 
   const disconnect = useCallback(() => {
-    setState((s) => ({ ...s, address: null, error: null }));
+    if (pollingRef.current) {
+      clearInterval(pollingRef.current);
+      pollingRef.current = null;
+    }
+    setState((s) => ({ ...s, address: null, balance: null, error: null, walletType: null }));
   }, []);
 
   const value = useMemo<WalletContextType>(
     () => ({
       address: state.address,
+      network: state.network,
+      balance: state.balance,
       isConnected,
       isConnecting: state.isConnecting,
       error: state.error,
+      walletType: state.walletType,
       connect,
       disconnect
     }),
-    [state.address, isConnected, state.isConnecting, state.error, connect, disconnect]
+    [state.address, state.network, state.balance, isConnected, state.isConnecting, state.error, state.walletType, connect, disconnect]
   );
 
   return <WalletContext.Provider value={value}>{children}</WalletContext.Provider>;


### PR DESCRIPTION
 Created implemented the web3: Integrate Stellar Wallet Connector (Freighter/Albedo)

Description
The dashboard currently lacks a way for users to sign transactions directly. We need to implement a unified wallet connection interface that supports the Stellar ecosystem's primary wallets: Freighter and Albedo.

Requirements
 Implement a useWallet hook to manage connection state (Address, Network, Connection Status).
 Add a "Connect Wallet" modal supporting Freighter (Extension) and Albedo (Web).
 Implement a listener for account/network changes to prevent "split-brain" states between the UI and the wallet.
 Display the user's XLM balance and truncated Public Key in the navigation header upon successful connection.
 
 closes #56 