### PR TITLE
Refactor generic to use react-hook-form and zod

### DIFF
--- a/src/components/DepositForm.tsx
+++ b/src/components/DepositForm.tsx
@@ -1,5 +1,6 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { FormInput } from './FormInput';
-import { useFormValidation } from '@/hooks/useFormValidation';
 import { depositSchema, DepositFormData } from '@/utils/validation';
 import { notify } from '@/utils/notifications';
 import { shortenAddress } from '@/utils/contractHelpers';
@@ -21,40 +22,45 @@ export default function DepositForm({
   statusMessage,
   transactionHash
 }: DepositFormProps) {
-  const initialValues: DepositFormData = {
-    amount: '',
-  };
-
   const {
-    getFieldProps,
-    shouldDisableSubmit,
+    register,
     handleSubmit,
     reset,
-  } = useFormValidation({
-    schema: depositSchema,
-    initialValues,
-    onSubmit: async (data) => {
-      await onDeposit(data.amount);
-      notify.success("Deposit Successful", `You have deposited ${data.amount} tokens.`);
-      reset();
-    },
+    formState: { errors, isValid, isDirty }
+  } = useForm<DepositFormData>({
+    resolver: zodResolver(depositSchema),
+    mode: 'onChange',
+    defaultValues: {
+      amount: '' as any,
+    }
   });
 
-  const amountProps = getFieldProps('amount');
+  const onSubmit = async (data: DepositFormData) => {
+    try {
+      await onDeposit(data.amount.toString());
+      notify.success("Deposit Successful", `You have deposited ${data.amount} tokens.`);
+      reset();
+    } catch (error) {
+      console.error('Deposit error:', error);
+    }
+  };
+
+  const shouldDisableSubmit = !isConnected || !isValid || !isDirty || isSubmitting;
 
   return (
     <section className="rounded-2xl border border-border-primary bg-background-primary/30 p-6">
       <div className="text-sm font-semibold text-text-primary">Deposit</div>
       <div className="mt-1 text-xs text-text-muted">Deposit tokens into the Axionvera vault.</div>
 
-      <form onSubmit={(e) => { e.preventDefault(); handleSubmit(); }} className="mt-5 space-y-4">
+      <form onSubmit={handleSubmit(onSubmit)} className="mt-5 space-y-4">
         <FormInput
-          {...amountProps}
+          {...register('amount')}
           id="deposit-amount"
           inputMode="decimal"
           placeholder="0.0"
           label="Amount"
           required
+          error={errors.amount}
           helperText="Enter amount between 0.0001 and 10,000"
         />
 
@@ -82,7 +88,7 @@ export default function DepositForm({
 
         <button
           type="submit"
-          disabled={!isConnected || shouldDisableSubmit() || isSubmitting}
+          disabled={shouldDisableSubmit}
           aria-label={isSubmitting ? "Submitting deposit" : "Deposit tokens"}
           className="w-full rounded-xl bg-axion-500 px-4 py-3 text-sm font-medium text-white shadow-lg shadow-axion-500/20 transition hover:bg-axion-400 disabled:cursor-not-allowed disabled:opacity-70"
         >

--- a/src/components/FormInput.tsx
+++ b/src/components/FormInput.tsx
@@ -1,22 +1,20 @@
 import { forwardRef } from 'react';
-import { FormFieldError } from '@/hooks/useFormValidation';
+import { FieldError } from 'react-hook-form';
 
 interface FormInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
-  error?: FormFieldError;
-  touched?: boolean;
+  error?: FieldError | { message?: string };
   helperText?: string;
   children?: React.ReactNode;
 }
 
 export const FormInput = forwardRef<HTMLInputElement, FormInputProps>(
-  ({ label, error, touched, helperText, children, className = '', ...props }, ref) => {
-    const hasError = error?.hasError && touched;
-    const showError = hasError && error?.message;
-    const { onChange, ...inputProps } = props;
+  ({ label, error, helperText, children, className = '', ...props }, ref) => {
+    const hasError = !!error;
+    const errorMessage = error?.message;
 
     return (
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-2 w-full">
         {label && (
           <label 
             htmlFor={props.id}
@@ -29,25 +27,27 @@ export const FormInput = forwardRef<HTMLInputElement, FormInputProps>(
           </label>
         )}
         
-        <input
-          ref={ref}
-          className={`
-            w-full rounded-xl border px-4 py-3 text-sm text-text-primary outline-none ring-0 
-            placeholder:text-text-muted transition-colors
-            ${hasError 
-              ? 'border-red-500/70 bg-red-500/5 focus:border-red-500' 
-              : 'border-border-primary bg-background-secondary/30 focus:border-axion-500/70'
-            }
-            ${className}
-          `}
-          {...inputProps}
-          onChange={(event) => onChange?.(event.target.value as never)}
-        />
+        <div className="relative">
+          <input
+            ref={ref}
+            className={`
+              w-full rounded-xl border px-4 py-3 text-sm text-text-primary outline-none ring-0 
+              placeholder:text-text-muted transition-colors
+              ${hasError 
+                ? 'border-red-500/70 bg-red-500/5 focus:border-red-500' 
+                : 'border-border-primary bg-background-secondary/30 focus:border-axion-500/70'
+              }
+              ${className}
+            `}
+            {...props}
+          />
+          {children}
+        </div>
         
         <div className="min-h-[1.25rem]">
-          {showError ? (
-            <p className="text-xs text-red-500 dark:text-red-400">{error.message}</p>
-          ) : helperText && !touched ? (
+          {errorMessage ? (
+            <p className="text-xs text-red-500 dark:text-red-400">{errorMessage}</p>
+          ) : helperText ? (
             <p className="text-xs text-text-muted">{helperText}</p>
           ) : null}
         </div>

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -1,5 +1,6 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { FormInput } from './FormInput';
-import { useFormValidation } from '@/hooks/useFormValidation';
 import { profileSchema, ProfileFormData } from '@/utils/validation';
 import { notify } from '@/utils/notifications';
 
@@ -19,27 +20,24 @@ export default function ProfileForm({ initialData, onSubmit }: ProfileFormProps)
   };
 
   const {
-    getFieldProps,
-    shouldDisableSubmit,
-    isSubmitting,
+    register,
     handleSubmit,
-  } = useFormValidation({
-    schema: profileSchema,
-    initialValues,
-    onSubmit: async (data) => {
-      if (onSubmit) {
-        await onSubmit(data);
-        notify.success("Profile Updated", "Your profile information has been saved successfully.");
-      }
-    },
+    watch,
+    formState: { errors, isDirty, isValid, isSubmitting }
+  } = useForm<ProfileFormData>({
+    resolver: zodResolver(profileSchema),
+    mode: 'onChange',
+    defaultValues: initialValues,
   });
 
-  const firstNameProps = getFieldProps('firstName');
-  const lastNameProps = getFieldProps('lastName');
-  const emailProps = getFieldProps('email');
-  const bioProps = getFieldProps('bio');
-  const websiteProps = getFieldProps('website');
-  const locationProps = getFieldProps('location');
+  const bioValue = watch('bio') || '';
+
+  const handleFormSubmit = async (data: ProfileFormData) => {
+    if (onSubmit) {
+      await onSubmit(data);
+      notify.success("Profile Updated", "Your profile information has been saved successfully.");
+    }
+  };
 
   return (
     <div className="rounded-2xl border border-border-primary bg-background-primary/30 p-6">
@@ -50,29 +48,32 @@ export default function ProfileForm({ initialData, onSubmit }: ProfileFormProps)
         </p>
       </div>
 
-      <form onSubmit={(e) => { e.preventDefault(); handleSubmit(); }} className="space-y-6">
+      <form onSubmit={handleSubmit(handleFormSubmit)} className="space-y-6">
         <div className="grid gap-4 md:grid-cols-2">
           <FormInput
-            {...firstNameProps}
+            {...register('firstName')}
             id="firstName"
             label="First Name"
             required
+            error={errors.firstName}
           />
           
           <FormInput
-            {...lastNameProps}
+            {...register('lastName')}
             id="lastName"
             label="Last Name"
             required
+            error={errors.lastName}
           />
         </div>
 
         <FormInput
-          {...emailProps}
+          {...register('email')}
           id="email"
           type="email"
           label="Email Address"
           required
+          error={errors.email}
           helperText="We'll never share your email with anyone else."
         />
 
@@ -82,14 +83,12 @@ export default function ProfileForm({ initialData, onSubmit }: ProfileFormProps)
           </label>
           <textarea
             id="bio"
-            value={bioProps.value}
-            onChange={(e) => bioProps.onChange(e.target.value)}
-            onBlur={bioProps.onBlur}
+            {...register('bio')}
             rows={4}
             className={`
               w-full rounded-xl border px-4 py-3 text-sm text-text-primary outline-none ring-0 
               placeholder:text-slate-500 transition-colors resize-none
-              ${bioProps.error?.hasError && bioProps.touched
+              ${errors.bio
                 ? 'border-red-500/70 bg-red-500/5 focus:border-red-500' 
                 : 'border-border-primary bg-background-secondary/30 focus:border-axion-500/70'
               }
@@ -98,32 +97,34 @@ export default function ProfileForm({ initialData, onSubmit }: ProfileFormProps)
             maxLength={500}
           />
           <div className="mt-1 flex justify-between">
-            {bioProps.error?.hasError && bioProps.touched ? (
-              <p className="text-xs text-red-500 dark:text-red-400">{bioProps.error.message}</p>
+            {errors.bio ? (
+              <p className="text-xs text-red-500 dark:text-red-400">{errors.bio.message}</p>
             ) : (
               <p className="text-xs text-slate-400 dark:text-slate-500 transition-colors">Optional: Brief description about yourself</p>
             )}
             <p className="text-xs text-slate-500">
-              {(bioProps.value || '').length}/500
+              {bioValue.length}/500
             </p>
           </div>
         </div>
 
         <div className="grid gap-4 md:grid-cols-2">
           <FormInput
-            {...websiteProps}
+            {...register('website')}
             id="website"
             type="url"
             label="Website"
             placeholder="https://example.com"
+            error={errors.website}
             helperText="Optional: Your personal or professional website"
           />
           
           <FormInput
-            {...locationProps}
+            {...register('location')}
             id="location"
             label="Location"
             placeholder="City, Country"
+            error={errors.location}
             helperText="Optional: Your current location"
           />
         </div>
@@ -138,7 +139,7 @@ export default function ProfileForm({ initialData, onSubmit }: ProfileFormProps)
           </button>
           <button
             type="submit"
-            disabled={shouldDisableSubmit()}
+            disabled={!isDirty || !isValid || isSubmitting}
             className="rounded-xl bg-axion-500 px-6 py-2 text-sm font-medium text-white shadow-lg shadow-axion-500/20 transition hover:bg-axion-400 disabled:cursor-not-allowed disabled:opacity-70"
           >
             {isSubmitting ? 'Saving...' : 'Save Changes'}

--- a/src/components/SecuritySettingsForm.tsx
+++ b/src/components/SecuritySettingsForm.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { FormInput } from './FormInput';
-import { useFormValidation } from '@/hooks/useFormValidation';
 import { securitySettingsSchema, SecuritySettingsFormData } from '@/utils/validation';
 
 interface SecuritySettingsFormProps {
@@ -21,22 +22,18 @@ export default function SecuritySettingsForm({ onSubmit }: SecuritySettingsFormP
   };
 
   const {
-    getFieldProps,
-    shouldDisableSubmit,
-    isSubmitting,
+    register,
     handleSubmit,
-    values,
-  } = useFormValidation({
-    schema: securitySettingsSchema,
-    initialValues,
-    onSubmit,
+    watch,
+    formState: { errors, isDirty, isValid, isSubmitting }
+  } = useForm<SecuritySettingsFormData>({
+    resolver: zodResolver(securitySettingsSchema),
+    mode: 'onChange',
+    defaultValues: initialValues,
   });
 
-  const currentPasswordProps = getFieldProps('currentPassword');
-  const newPasswordProps = getFieldProps('newPassword');
-  const confirmPasswordProps = getFieldProps('confirmPassword');
-
-  const hasNewPassword = !!values.newPassword && values.newPassword.length > 0;
+  const newPassword = watch('newPassword') || '';
+  const hasNewPassword = newPassword.length > 0;
 
   return (
     <div className="rounded-2xl border border-border-primary bg-background-primary/30 p-6">
@@ -47,16 +44,17 @@ export default function SecuritySettingsForm({ onSubmit }: SecuritySettingsFormP
         </p>
       </div>
 
-      <form onSubmit={(e) => { e.preventDefault(); handleSubmit(); }} className="space-y-6">
+      <form onSubmit={handleSubmit(onSubmit || (() => {}))} className="space-y-6">
         <div>
           <h3 className="text-sm font-medium text-text-primary mb-4">Change Password</h3>
           
           <FormInput
-            {...currentPasswordProps}
+            {...register('currentPassword')}
             id="currentPassword"
             type={showPasswords.current ? 'text' : 'password'}
             label="Current Password"
             required
+            error={errors.currentPassword}
           >
             <div className="absolute inset-y-0 right-0 flex items-center pr-3">
               <button
@@ -67,12 +65,12 @@ export default function SecuritySettingsForm({ onSubmit }: SecuritySettingsFormP
               >
                 {showPasswords.current ? (
                   <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268-2.943-9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
                   </svg>
                 ) : (
                   <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
                     <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268-2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
                   </svg>
                 )}
               </button>
@@ -80,11 +78,12 @@ export default function SecuritySettingsForm({ onSubmit }: SecuritySettingsFormP
           </FormInput>
 
           <FormInput
-            {...newPasswordProps}
+            {...register('newPassword')}
             id="newPassword"
             type={showPasswords.new ? 'text' : 'password'}
             label="New Password"
             required={hasNewPassword}
+            error={errors.newPassword}
             helperText={!hasNewPassword ? "Leave blank to keep current password" : "Must be at least 8 characters with uppercase, lowercase, number, and special character"}
           >
             <div className="absolute inset-y-0 right-0 flex items-center pr-3">
@@ -96,12 +95,12 @@ export default function SecuritySettingsForm({ onSubmit }: SecuritySettingsFormP
               >
                 {showPasswords.new ? (
                   <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268-2.943-9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
                   </svg>
                 ) : (
                   <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
                     <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268-2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
                   </svg>
                 )}
               </button>
@@ -109,11 +108,12 @@ export default function SecuritySettingsForm({ onSubmit }: SecuritySettingsFormP
           </FormInput>
 
           <FormInput
-            {...confirmPasswordProps}
+            {...register('confirmPassword')}
             id="confirmPassword"
             type={showPasswords.confirm ? 'text' : 'password'}
             label="Confirm New Password"
             required={hasNewPassword}
+            error={errors.confirmPassword}
             helperText={!hasNewPassword ? "Leave blank if not changing password" : "Re-enter your new password to confirm"}
           >
             <div className="absolute inset-y-0 right-0 flex items-center pr-3">
@@ -125,12 +125,12 @@ export default function SecuritySettingsForm({ onSubmit }: SecuritySettingsFormP
               >
                 {showPasswords.confirm ? (
                   <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268-2.943-9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
                   </svg>
                 ) : (
                   <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
                     <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268-2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
                   </svg>
                 )}
               </button>
@@ -145,19 +145,19 @@ export default function SecuritySettingsForm({ onSubmit }: SecuritySettingsFormP
             <div className="space-y-1">
               <div className="flex items-center gap-2">
                 <div className={`h-1 flex-1 rounded-full ${
-                  (values.newPassword || '').length >= 8 ? 'bg-green-500' : 'bg-slate-700'
+                  newPassword.length >= 8 ? 'bg-green-500' : 'bg-slate-700'
                 }`} />
                 <div className={`h-1 flex-1 rounded-full ${
-                  /[A-Z]/.test(values.newPassword || '') ? 'bg-green-500' : 'bg-slate-700'
+                  /[A-Z]/.test(newPassword) ? 'bg-green-500' : 'bg-slate-700'
                 }`} />
                 <div className={`h-1 flex-1 rounded-full ${
-                  /[a-z]/.test(values.newPassword || '') ? 'bg-green-500' : 'bg-slate-700'
+                  /[a-z]/.test(newPassword) ? 'bg-green-500' : 'bg-slate-700'
                 }`} />
                 <div className={`h-1 flex-1 rounded-full ${
-                  /[0-9]/.test(values.newPassword || '') ? 'bg-green-500' : 'bg-slate-700'
+                  /[0-9]/.test(newPassword) ? 'bg-green-500' : 'bg-slate-700'
                 }`} />
                 <div className={`h-1 flex-1 rounded-full ${
-                  /[^A-Za-z0-9]/.test(values.newPassword || '') ? 'bg-green-500' : 'bg-slate-700'
+                  /[^A-Za-z0-9]/.test(newPassword) ? 'bg-green-500' : 'bg-slate-700'
                 }`} />
               </div>
               <div className="grid grid-cols-5 gap-2 text-xs text-slate-400 dark:text-slate-500 transition-colors">
@@ -181,7 +181,7 @@ export default function SecuritySettingsForm({ onSubmit }: SecuritySettingsFormP
           </button>
           <button
             type="submit"
-            disabled={shouldDisableSubmit()}
+            disabled={!isDirty || !isValid || isSubmitting}
             className="rounded-xl bg-axion-500 px-6 py-2 text-sm font-medium text-white shadow-lg shadow-axion-500/20 transition hover:bg-axion-400 disabled:cursor-not-allowed disabled:opacity-70"
           >
             {isSubmitting ? 'Updating...' : 'Update Password'}

--- a/src/components/WithdrawForm.tsx
+++ b/src/components/WithdrawForm.tsx
@@ -1,6 +1,7 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { FormInput } from './FormInput';
-import { useFormValidation } from '@/hooks/useFormValidation';
-import { withdrawSchema, WithdrawFormData } from '@/utils/validation';
+import { createWithdrawSchema, WithdrawFormData } from '@/utils/validation';
 import { notify } from '@/utils/notifications';
 import { formatAmount, shortenAddress } from '@/utils/contractHelpers';
 
@@ -23,26 +24,30 @@ export default function WithdrawForm({
   statusMessage,
   transactionHash
 }: WithdrawFormProps) {
-  const initialValues: WithdrawFormData = {
-    amount: '',
-  };
-
   const {
-    getFieldProps,
-    shouldDisableSubmit,
+    register,
     handleSubmit,
     reset,
-  } = useFormValidation({
-    schema: withdrawSchema,
-    initialValues,
-    onSubmit: async (data) => {
-      await onWithdraw(data.amount);
-      notify.success("Withdrawal Successful", `You have withdrawn ${data.amount} tokens.`);
-      reset();
-    },
+    formState: { errors, isValid, isDirty }
+  } = useForm<WithdrawFormData>({
+    resolver: zodResolver(createWithdrawSchema(parseFloat(balance))),
+    mode: 'onChange',
+    defaultValues: {
+      amount: '' as any,
+    }
   });
 
-  const amountProps = getFieldProps('amount');
+  const onSubmit = async (data: WithdrawFormData) => {
+    try {
+      await onWithdraw(data.amount.toString());
+      notify.success("Withdrawal Successful", `You have withdrawn ${data.amount} tokens.`);
+      reset();
+    } catch (error) {
+      console.error('Withdrawal error:', error);
+    }
+  };
+
+  const shouldDisableSubmit = !isConnected || !isValid || !isDirty || isSubmitting;
 
   return (
     <section className="rounded-2xl border border-border-primary bg-background-primary/30 p-6">
@@ -52,15 +57,16 @@ export default function WithdrawForm({
         Available balance: <span className="font-medium text-text-primary">{formatAmount(balance)}</span>
       </div>
 
-      <form onSubmit={(e) => { e.preventDefault(); handleSubmit(); }} className="mt-5 space-y-4">
+      <form onSubmit={handleSubmit(onSubmit)} className="mt-5 space-y-4">
         <FormInput
-          {...amountProps}
+          {...register('amount')}
           id="withdraw-amount"
           inputMode="decimal"
           placeholder="0.0"
           label="Amount"
           required
-          helperText="Enter amount between 0.0001 and 10,000"
+          error={errors.amount}
+          helperText={`Enter amount between 0.0001 and ${formatAmount(balance)}`}
         />
 
         {status !== 'idle' ? (
@@ -87,7 +93,7 @@ export default function WithdrawForm({
 
         <button
           type="submit"
-          disabled={!isConnected || shouldDisableSubmit() || isSubmitting}
+          disabled={shouldDisableSubmit}
           aria-label={isSubmitting ? "Submitting withdrawal" : "Withdraw tokens"}
           className="w-full rounded-xl border border-border-primary bg-background-secondary/30 px-4 py-3 text-sm font-medium text-text-primary transition hover:bg-background-secondary/60 disabled:cursor-not-allowed disabled:opacity-60"
         >

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -96,22 +96,27 @@ export const settingsSchema = z.object({
 
 // Deposit/Withdraw form schemas
 export const depositSchema = z.object({
-  amount: z
-    .string()
-    .min(1, 'Amount is required')
-    .regex(/^\d*\.?\d+$/, 'Invalid amount format')
-    .refine((val) => parseFloat(val) > 0, 'Amount must be greater than 0')
-    .refine((val) => parseFloat(val) <= 10000, 'Amount cannot exceed 10,000'),
+  amount: z.coerce
+    .number({
+      required_error: 'Amount is required',
+      invalid_type_error: 'Amount must be a valid number',
+    })
+    .positive('Amount must be greater than 0')
+    .max(10000, 'Amount cannot exceed 10,000'),
 });
 
-export const withdrawSchema = z.object({
-  amount: z
-    .string()
-    .min(1, 'Amount is required')
-    .regex(/^\d*\.?\d+$/, 'Invalid amount format')
-    .refine((val) => parseFloat(val) > 0, 'Amount must be greater than 0')
-    .refine((val) => parseFloat(val) <= 10000, 'Amount cannot exceed 10,000'),
-});
+export const createWithdrawSchema = (maxBalance: number) => 
+  z.object({
+    amount: z.coerce
+      .number({
+        required_error: 'Amount is required',
+        invalid_type_error: 'Amount must be a valid number',
+      })
+      .positive('Amount must be greater than 0')
+      .max(maxBalance, `Amount cannot exceed your balance of ${maxBalance}`),
+  });
+
+export const withdrawSchema = createWithdrawSchema(10000); // Default for types
 
 // Type exports
 export type ProfileFormData = z.infer<typeof profileSchema>;


### PR DESCRIPTION
Closes #68

---

Close: #67

I have successfully refactored the forms in the Axionvera dashboard to use react-hook-form and zod. This change improves performance by reducing unnecessary re-renders and provides stricter, more immediate validation for critical transactions.

Key Accomplishments:
FormInput.tsx: Updated the core input component to be fully compatible with react-hook-form. I also fixed a bug where children (like password visibility toggles) were not being rendered.
Strict Validation: Refactored the Deposit and Withdraw schemas to use numeric validation. The Withdraw form now dynamically validates the input amount against the user's current balance.
Immediate Feedback: Set the forms to onChange validation mode, ensuring users see inline errors immediately if they enter invalid data (e.g., negative numbers or amounts exceeding their balance).
Comprehensive Refactoring: Beyond Deposit and Withdraw, I also refactored the Profile and Security Settings forms to maintain consistency across the codebase and ensure they work with the updated FormInput component.
