### PR TITLE
Optimize Docker build for Next.js standalone output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,35 +13,44 @@ RUN npm ci
 # Copy source code
 COPY . .
 
-# Build the application
+# Build the application with standalone output
 RUN npm run build
 
-# Production dependencies stage
-FROM node:18-alpine AS deps
+# Production Stage
+FROM node:18-alpine AS runner
 
+# Set working directory
 WORKDIR /app
 
-COPY package*.json ./
-RUN npm ci --only=production && npm cache clean --force
+# Set environment to production
+ENV NODE_ENV=production
 
-# Serve Stage
-FROM nginx:alpine AS server
+# Create non-root user for security
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
 
-# Copy custom nginx config
-COPY nginx.conf /etc/nginx/nginx.conf
+# Copy only the necessary files from builder
+# .next/standalone includes the minimal node_modules and server.js
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/public ./public
 
-# Copy built assets from builder stage
-COPY --from=builder /app/.next /usr/share/nginx/html/.next
-COPY --from=builder /app/public /usr/share/nginx/html/public
-COPY --from=deps /app/node_modules /usr/share/nginx/html/node_modules
-COPY --from=builder /app/package.json /usr/share/nginx/html/
-# Expose port 80
-EXPOSE 80
+# Copy package.json for reference
+COPY --from=builder /app/package.json ./
 
 # Make scripts directory and copy env script
 RUN mkdir -p /app/scripts
-COPY scripts/env.sh /app/scripts/env.sh
+COPY --from=builder /app/scripts/env.sh /app/scripts/env.sh
 RUN chmod +x /app/scripts/env.sh
 
-# Start with script execution then nginx
-CMD ["/bin/sh", "-c", "/app/scripts/env.sh /usr/share/nginx/html/env-config.js && nginx -g 'daemon off;'"]
+# Change ownership to non-root user
+RUN chown -R nextjs:nodejs /app
+
+# Switch to non-root user
+USER nextjs
+
+# Expose port 3000 (default Next.js port)
+EXPOSE 3000
+
+# Start with script execution then Next.js server
+CMD ["/bin/sh", "-c", "/app/scripts/env.sh /app/env-config.js && node server.js"]

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  output: 'standalone'
 };
 
 export default nextConfig;


### PR DESCRIPTION
- Add output: 'standalone' to next.config.mjs
- Refactor Dockerfile to use multi-stage build with standalone mode
- Copy only .next/standalone directory and public/ folder in final stage
- Remove nginx and separate deps stage for minimal image size
- Change to node:18-alpine runner with non-root user
- Update port to 3000 and use node server.js for serving

This drastically reduces Docker image size (target under 150MB) and improves deployment times.

closes #73 