### PR TITLE
feat(wallet): implement wallet session persistence

### DIFF
--- a/src/components/TransactionHistory.tsx
+++ b/src/components/TransactionHistory.tsx
@@ -215,7 +215,7 @@ export default function TransactionHistory({
                   <span className="text-text-muted">{new Date(tx.createdAt).toLocaleString()}</span>
                 </div>
                 {tx.hash ? <div className="text-xs text-text-muted">Hash: {shortenAddress(tx.hash, 8)}</div> : null}
-              </article>
+              </div>
             ))
           )}
         </div>

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -1,14 +1,15 @@
 import React, {
   createContext,
-  useContext,
   useCallback,
+  useContext,
   useEffect,
   useMemo,
-  useState,
-  ReactNode,
   useRef,
+  useState,
+  type ReactNode,
 } from "react";
-import { StellarNetwork, NETWORK, HORIZON_URL } from "@/utils/networkConfig";
+
+import { NETWORK, type StellarNetwork } from "@/utils/networkConfig";
 
 type WalletType = "freighter" | "albedo";
 
@@ -23,18 +24,75 @@ type WalletState = {
 
 interface WalletContextType {
   address: string | null;
-  publicKey: string | null; // Alias for acceptance criteria
+  publicKey: string | null;
   network: StellarNetwork;
   balance: string | null;
   isConnected: boolean;
   isConnecting: boolean;
   error: string | null;
   walletType: WalletType | null;
-  connect: (walletType: WalletType) => Promise<void>;
+  connect: (walletType?: WalletType) => Promise<void>;
   disconnect: () => void;
 }
 
 const WalletContext = createContext<WalletContextType | undefined>(undefined);
+
+const WALLET_WAS_CONNECTED_KEY = "axionvera:wallet:was_connected";
+const LAST_WALLET_TYPE_KEY = "axionvera:wallet:last_type";
+
+function mapFreighterNetwork(network: string): StellarNetwork {
+  const networkMap: Record<string, StellarNetwork> = {
+    PUBLIC: "mainnet",
+    TESTNET: "testnet",
+    FUTURENET: "futurenet",
+  };
+
+  return networkMap[network] ?? "testnet";
+}
+
+function getLastWalletType(): WalletType | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const value = window.localStorage.getItem(LAST_WALLET_TYPE_KEY);
+    return value === "freighter" || value === "albedo" ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function setWalletPersistence(walletType: WalletType) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(WALLET_WAS_CONNECTED_KEY, "true");
+    window.localStorage.setItem(LAST_WALLET_TYPE_KEY, walletType);
+  } catch {
+    // Ignore localStorage errors in restricted environments.
+  }
+}
+
+function clearWalletPersistence() {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(WALLET_WAS_CONNECTED_KEY);
+    window.localStorage.removeItem(LAST_WALLET_TYPE_KEY);
+  } catch {
+    // Ignore localStorage errors in restricted environments.
+  }
+}
+
+function shouldAttemptFreighterReconnect(): boolean {
+  if (typeof window === "undefined") return false;
+
+  try {
+    const wasConnected =
+      window.localStorage.getItem(WALLET_WAS_CONNECTED_KEY) === "true";
+    const lastWalletType = getLastWalletType();
+
+    return wasConnected && lastWalletType === "freighter";
+  } catch {
+    return false;
+  }
+}
 
 async function loadFreighter() {
   const mod = await import("@stellar/freighter-api");
@@ -71,15 +129,6 @@ async function fetchBalance(
   }
 }
 
-function setWalletCookie() {
-  document.cookie = "hasWallet=true; path=/; SameSite=Lax";
-}
-
-function clearWalletCookie() {
-  document.cookie = "hasWallet=; path=/; max-age=0";
-}
-
-
 export function WalletProvider({ children }: { children: ReactNode }) {
   const [state, setState] = useState<WalletState>({
     address: null,
@@ -94,16 +143,16 @@ export function WalletProvider({ children }: { children: ReactNode }) {
 
   const isConnected = useMemo(() => Boolean(state.address), [state.address]);
 
-  // Fetch balance when address changes
   useEffect(() => {
     if (!state.address) {
       setState((s) => ({ ...s, balance: null }));
       return;
     }
+    const walletAddress = state.address;
 
     let cancelled = false;
     (async () => {
-      const balance = await fetchBalance(state.address!, state.network);
+      const balance = await fetchBalance(walletAddress, state.network);
       if (!cancelled) {
         setState((s) => ({ ...s, balance }));
       }
@@ -114,42 +163,26 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     };
   }, [state.address, state.network]);
 
-  // Poll for account/network changes
   useEffect(() => {
-    if (!state.address || !state.walletType) return;
+    if (!state.address || state.walletType !== "freighter") return;
+    const activeAddress = state.address;
 
     const checkForChanges = async () => {
       try {
-        if (state.walletType === "freighter") {
-          const freighter = await loadFreighter();
-          const currentAddress = await freighter.getPublicKey();
-          const currentNetwork = await freighter.getNetwork();
+        const freighter = await loadFreighter();
+        const currentAddress = await freighter.getPublicKey();
+        const currentNetwork = await freighter.getNetwork();
+        const mappedNetwork = mapFreighterNetwork(currentNetwork);
 
-          // Map Freighter network names to our StellarNetwork type
-          const networkMap: Record<string, StellarNetwork> = {
-            PUBLIC: "mainnet",
-            TESTNET: "testnet",
-            FUTURENET: "futurenet",
-          };
-
-          const mappedNetwork = networkMap[currentNetwork] ?? "testnet";
-
-          if (
-            currentAddress !== state.address ||
-            mappedNetwork !== state.network
-          ) {
-            setState((s) => ({
-              ...s,
-              address: currentAddress,
-              network: mappedNetwork,
-            }));
-          }
-        } else if (state.walletType === "albedo") {
-          // Albedo doesn't provide network info, so we use the configured network
-          // We can't poll for address changes with Albedo
+        if (currentAddress !== activeAddress || mappedNetwork !== state.network) {
+          setState((s) => ({
+            ...s,
+            address: currentAddress,
+            network: mappedNetwork,
+          }));
         }
       } catch {
-        // Ignore polling errors
+        // Ignore polling errors.
       }
     };
 
@@ -163,27 +196,31 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     };
   }, [state.address, state.walletType, state.network]);
 
-  // Check for existing Freighter connection on mount
   useEffect(() => {
+    if (!shouldAttemptFreighterReconnect()) {
+      return;
+    }
+
     let cancelled = false;
+
     (async () => {
-      if (typeof window === "undefined") return;
       try {
         const freighter = await loadFreighter();
         const connected = await freighter.isConnected();
-        if (!connected) return;
+        if (!connected) {
+          clearWalletPersistence();
+          return;
+        }
+
         const allowed = await freighter.isAllowed();
-        if (!allowed) return;
+        if (!allowed) {
+          clearWalletPersistence();
+          return;
+        }
+
         const address = await freighter.getPublicKey();
         const network = await freighter.getNetwork();
-
-        const networkMap: Record<string, StellarNetwork> = {
-          PUBLIC: "mainnet",
-          TESTNET: "testnet",
-          FUTURENET: "futurenet",
-        };
-
-        const mappedNetwork = networkMap[network] ?? "testnet";
+        const mappedNetwork = mapFreighterNetwork(network);
 
         if (!cancelled) {
           setState((s) => ({
@@ -192,9 +229,11 @@ export function WalletProvider({ children }: { children: ReactNode }) {
             network: mappedNetwork,
             walletType: "freighter",
             error: null,
+            isConnecting: false,
           }));
         }
       } catch {
+        clearWalletPersistence();
         if (!cancelled) {
           setState((s) => ({ ...s, address: null, walletType: null }));
         }
@@ -206,30 +245,28 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     };
   }, []);
 
-  const connect = useCallback(async (walletType: WalletType) => {
+  const connect = useCallback(async (walletType: WalletType = "freighter") => {
     setState((s) => ({ ...s, isConnecting: true, error: null }));
+
     try {
-      if (typeof window === "undefined")
+      if (typeof window === "undefined") {
         throw new Error("Wallet is only available in the browser.");
+      }
 
       if (walletType === "freighter") {
         const freighter = await loadFreighter();
         const connected = await freighter.isConnected();
-        if (!connected)
+        if (!connected) {
           throw new Error(
             "Freighter wallet not detected. Please install the Freighter extension.",
           );
+        }
+
         await freighter.setAllowed();
-        address = await freighter.getPublicKey();
+
+        const address = await freighter.getPublicKey();
         const network = await freighter.getNetwork();
-
-        const networkMap: Record<string, StellarNetwork> = {
-          PUBLIC: "mainnet",
-          TESTNET: "testnet",
-          FUTURENET: "futurenet",
-        };
-
-        const mappedNetwork = networkMap[network] ?? "testnet";
+        const mappedNetwork = mapFreighterNetwork(network);
 
         setState({
           address,
@@ -239,27 +276,27 @@ export function WalletProvider({ children }: { children: ReactNode }) {
           error: null,
           walletType: "freighter",
         });
-      } else if (walletType === "albedo") {
-        const albedo = await loadAlbedo();
-        const result = await albedo.publicKey({});
-        const address = result.pubkey;
-
-        // Albedo doesn't provide network info, use configured network
-        setState({
-          address,
-          network: NETWORK,
-          balance: null,
-          isConnecting: false,
-          error: null,
-          walletType: "albedo",
-        });
+        setWalletPersistence("freighter");
+        return;
       }
 
-      setState({ address, network: mappedNetwork, balance: null, isConnecting: false, error: null, walletType });
-      notify.success('Wallet Connected', `Successfully connected to ${walletType} wallet.`);
-    } catch (e) {
+      const albedo = await loadAlbedo();
+      const result = await albedo.publicKey({});
+      const address = result.pubkey;
+
+      setState({
+        address,
+        network: NETWORK,
+        balance: null,
+        isConnecting: false,
+        error: null,
+        walletType: "albedo",
+      });
+      setWalletPersistence("albedo");
+    } catch (error) {
       const message =
-        e instanceof Error ? e.message : "Failed to connect wallet.";
+        error instanceof Error ? error.message : "Failed to connect wallet.";
+
       setState((s) => ({
         ...s,
         isConnecting: false,
@@ -275,6 +312,8 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       clearInterval(pollingRef.current);
       pollingRef.current = null;
     }
+
+    clearWalletPersistence();
     setState((s) => ({
       ...s,
       address: null,
@@ -287,7 +326,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
   const value = useMemo<WalletContextType>(
     () => ({
       address: state.address,
-      publicKey: state.address, // Expose publicKey as alias for address
+      publicKey: state.address,
       network: state.network,
       balance: state.balance,
       isConnected,
@@ -323,6 +362,5 @@ export function useWalletContext() {
   return context;
 }
 
-// Keep useWallet as a deprecated alias to facilitate refactoring
 /** @deprecated Use useWalletContext instead */
 export const useWallet = useWalletContext;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -59,7 +59,7 @@ export default function HomePage() {
                 <>
                   <button
                     type="button"
-                    onClick={connect}
+                    onClick={() => void connect()}
                     disabled={isConnecting}
                     aria-label={isConnecting ? "Connecting to Stellar wallet" : "Connect Stellar wallet"}
                     className="inline-flex items-center justify-center rounded-xl bg-axion-500 px-5 py-3 text-sm font-medium text-white shadow-lg shadow-axion-500/20 transition hover:bg-axion-400 disabled:cursor-not-allowed disabled:opacity-70"

--- a/tests/hooks/useWallet.test.ts
+++ b/tests/hooks/useWallet.test.ts
@@ -1,34 +1,38 @@
 import React, { type ReactNode } from "react";
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 
+import * as freighterApi from "@stellar/freighter-api";
 import { useWallet } from "@/hooks/useWallet";
 
 jest.mock("@stellar/freighter-api", () => ({
   isConnected: jest.fn(async () => true),
   isAllowed: jest.fn(async () => true),
   setAllowed: jest.fn(async () => undefined),
-  getPublicKey: jest.fn(async () => "GCONNECTEDPUBLICKEY")
+  getPublicKey: jest.fn(async () => "GCONNECTEDPUBLICKEY"),
+  getNetwork: jest.fn(async () => "TESTNET"),
 }));
 
 describe("useWallet", () => {
+  const mockedFreighter = freighterApi as jest.Mocked<typeof freighterApi>;
+
   function wrapper({ children }: { children: ReactNode }) {
-    try {
-      const walletContextModule = require("@/contexts/WalletContext") as {
-        WalletProvider?: ({ children }: { children: ReactNode }) => JSX.Element;
-      };
+    const { WalletProvider } = require("@/contexts/WalletContext") as {
+      WalletProvider: ({ children }: { children: ReactNode }) => JSX.Element;
+    };
 
-      if (walletContextModule.WalletProvider) {
-        const WalletProvider = walletContextModule.WalletProvider;
-        return React.createElement(WalletProvider, null, children);
-      }
-    } catch {
-      // Some branches expose useWallet directly without a provider-backed context.
-    }
-
-    return React.createElement(React.Fragment, null, children);
+    return React.createElement(WalletProvider, null, children);
   }
 
-  test("connect sets address", async () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+    mockedFreighter.isConnected.mockResolvedValue(true);
+    mockedFreighter.isAllowed.mockResolvedValue(true);
+    mockedFreighter.getPublicKey.mockResolvedValue("GCONNECTEDPUBLICKEY");
+    mockedFreighter.getNetwork.mockResolvedValue("TESTNET");
+  });
+
+  test("connect defaults to freighter and sets address", async () => {
     const { result } = renderHook(() => useWallet(), { wrapper });
 
     await act(async () => {
@@ -37,9 +41,11 @@ describe("useWallet", () => {
 
     expect(result.current.address).toBe("GCONNECTEDPUBLICKEY");
     expect(result.current.isConnected).toBe(true);
+    expect(localStorage.getItem("axionvera:wallet:was_connected")).toBe("true");
+    expect(localStorage.getItem("axionvera:wallet:last_type")).toBe("freighter");
   });
 
-  test("disconnect clears address", async () => {
+  test("disconnect clears persisted wallet flags", async () => {
     const { result } = renderHook(() => useWallet(), { wrapper });
 
     await act(async () => {
@@ -52,5 +58,28 @@ describe("useWallet", () => {
 
     expect(result.current.address).toBeNull();
     expect(result.current.isConnected).toBe(false);
+    expect(localStorage.getItem("axionvera:wallet:was_connected")).toBeNull();
+    expect(localStorage.getItem("axionvera:wallet:last_type")).toBeNull();
+  });
+
+  test("does not attempt silent reconnect without persisted flag", () => {
+    renderHook(() => useWallet(), { wrapper });
+
+    expect(mockedFreighter.isAllowed).not.toHaveBeenCalled();
+    expect(mockedFreighter.getPublicKey).not.toHaveBeenCalled();
+  });
+
+  test("silently reconnects when persisted freighter session is present", async () => {
+    localStorage.setItem("axionvera:wallet:was_connected", "true");
+    localStorage.setItem("axionvera:wallet:last_type", "freighter");
+
+    const { result } = renderHook(() => useWallet(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.address).toBe("GCONNECTEDPUBLICKEY");
+    });
+
+    expect(mockedFreighter.isAllowed).toHaveBeenCalledTimes(1);
+    expect(result.current.walletType).toBe("freighter");
   });
 });


### PR DESCRIPTION
Closes #112

Summary
- persist wallet session intent in localStorage after successful connect
- on app init, only attempt silent reconnect when persisted flag exists and last wallet was Freighter
- verify session against Freighter APIs (`isConnected`, `isAllowed`, `getPublicKey`, `getNetwork`) before setting public key state
- clear persistence on disconnect or when silent reconnect validation fails
- keep key safety: localStorage is not used as source-of-truth for public key

Additional fix
- corrected mismatched JSX closing tag in `src/components/TransactionHistory.tsx` (`</article>` -> `</div>`) to keep branch buildable

Testing
- `npm test -- tests/hooks/useWallet.test.ts`
  - connect defaults to freighter and sets persistence flags
  - disconnect clears persistence flags
  - no silent reconnect without persisted flag
  - silent reconnect works when persisted freighter session exists
