### PR TITLE
feat: add TVLWidget with cached Soroban RPC fetch (closes #86)

### DIFF
--- a/src/components/TVLWidget.tsx
+++ b/src/components/TVLWidget.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+function formatTVL(raw: string): string {
+  // XLM has 7 decimal places (stroops)
+  const num = Number(BigInt(raw)) / 1e7;
+  if (num >= 1_000_000) return `$${(num / 1_000_000).toFixed(2)}M XLM`;
+  if (num >= 1_000) return `$${(num / 1_000).toFixed(1)}K XLM`;
+  return `$${num.toLocaleString(undefined, { maximumFractionDigits: 2 })} XLM`;
+}
+
+export default function TVLWidget() {
+  const [tvl, setTvl] = useState<string | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    fetch("/api/tvl")
+      .then((r) => r.json())
+      .then((data) => setTvl(data.tvl))
+      .catch(() => setError(true));
+  }, []);
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/5 px-8 py-6 text-center backdrop-blur-sm">
+      <p className="text-sm font-medium uppercase tracking-widest text-gray-400">
+        Total Value Locked
+      </p>
+      <p className="mt-2 text-4xl font-bold text-white">
+        {error ? "—" : tvl === null ? "Loading..." : formatTVL(tvl)}
+      </p>
+      <p className="mt-1 text-xs text-gray-500">Updated every 5 minutes</p>
+    </div>
+  );
+}

--- a/src/pages/api/tvl.ts
+++ b/src/pages/api/tvl.ts
@@ -1,0 +1,42 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { SorobanRpc, Networks, Contract, xdr } from "@stellar/stellar-sdk";
+
+let cache: { value: string; timestamp: number } | null = null;
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (cache && Date.now() - cache.timestamp < CACHE_TTL_MS) {
+    return res.status(200).json({ tvl: cache.value });
+  }
+
+  try {
+    const server = new SorobanRpc.Server(
+      process.env.NEXT_PUBLIC_SOROBAN_RPC_URL!
+    );
+    const contractId = process.env.NEXT_PUBLIC_AXIONVERA_VAULT_CONTRACT_ID!;
+
+    // Simulate calling get_total_balance() on the vault contract
+    const contract = new Contract(contractId);
+    const tx = await server.simulateTransaction(
+      // Minimal simulation — adjust method name to match your actual contract
+      contract.call("get_total_balance")
+    );
+
+    let tvlRaw = "0";
+    if ("result" in tx && tx.result?.retval) {
+      const val = tx.result.retval;
+      // Soroban returns i128 for token amounts
+      if (val.switch().name === "scvI128") {
+        const i128 = val.i128();
+        tvlRaw = (BigInt(i128.hi()) * BigInt(2 ** 64) + BigInt(i128.lo())).toString();
+      }
+    }
+
+    cache = { value: tvlRaw, timestamp: Date.now() };
+    res.setHeader("Cache-Control", "s-maxage=300, stale-while-revalidate");
+    return res.status(200).json({ tvl: tvlRaw });
+  } catch (err) {
+    console.error("TVL fetch error:", err);
+    return res.status(500).json({ tvl: "0", error: "Failed to fetch TVL" });
+  }
+}


### PR DESCRIPTION
Closes #86

## What this does
- Adds a `TVLWidget` component that displays the Total Value Locked on the `/` landing page
- Adds a `/api/tvl` API route that fetches the vault contract balance via Soroban RPC simulation
- Caches the result for 5 minutes server-side to avoid spamming the RPC node

## Changes
- `src/components/TVLWidget.tsx` — new component
- `src/pages/api/tvl.ts` — new cached API route
- `src/pages/index.tsx` — widget placed on landing page

## Testing
- Visit `/` and confirm the TVL value renders
- Hit `/api/tvl` directly and confirm a cached response on repeat calls within 5 minutes