### PR TITLE
feat(tests): mock Freighter API context for component testing

### DIFF
--- a/tests/DepositForm.test.tsx
+++ b/tests/DepositForm.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * DepositForm — integration tests
+ *
+ * Uses WalletContextMock so the real Freighter extension is never imported.
+ * DepositForm receives wallet state as direct props, so each test simply
+ * passes the relevant prop values; the mock provider is included so that
+ * any child component that reads WalletContext also works without crashing.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import DepositForm from '@/components/DepositForm';
+import { WalletContextMock } from '@/tests/mocks/WalletContextMock';
+
+// ── Shared props ──────────────────────────────────────────────────────────────
+
+const baseProps = {
+  isConnected:    true,
+  isSubmitting:   false,
+  onDeposit:      jest.fn().mockResolvedValue(undefined),
+  status:         'idle' as const,
+  statusMessage:  null,
+  transactionHash: null,
+  walletBalance:  100,
+};
+
+function renderDepositForm(overrides: Partial<typeof baseProps> = {}) {
+  const props = { ...baseProps, ...overrides };
+  return render(
+    <WalletContextMock>
+      <DepositForm {...props} />
+    </WalletContextMock>,
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('DepositForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  /**
+   * Core acceptance-criteria test (issue #97):
+   * The submit button must be disabled when the amount field is empty / zero
+   * so the user cannot submit a no-op deposit.
+   */
+  it('submit button is disabled when amount input is empty (zero)', () => {
+    renderDepositForm();
+
+    // The amount field starts empty — no value has been typed yet.
+    const submitButton = screen.getByRole('button', { name: /deposit/i });
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('submit button is disabled when wallet is not connected', () => {
+    renderDepositForm({ isConnected: false });
+
+    const submitButton = screen.getByRole('button', { name: /deposit/i });
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('submit button shows "Submitting…" and is disabled while a deposit is in flight', () => {
+    renderDepositForm({ isSubmitting: true });
+
+    const submitButton = screen.getByRole('button', { name: /submitting deposit/i });
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('renders the amount input field', () => {
+    renderDepositForm();
+
+    const input = screen.getByPlaceholderText('0.0');
+    expect(input).toBeInTheDocument();
+  });
+
+  it('shows a pending status message when status is pending', () => {
+    renderDepositForm({
+      status: 'pending',
+      statusMessage: 'Awaiting confirmation…',
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent('Deposit transaction pending');
+    expect(screen.getByRole('status')).toHaveTextContent('Awaiting confirmation…');
+  });
+
+  it('shows an error status message when status is error', () => {
+    renderDepositForm({
+      status: 'error',
+      statusMessage: 'Transaction rejected by the network.',
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent('Deposit failed');
+    expect(screen.getByRole('status')).toHaveTextContent('Transaction rejected by the network.');
+  });
+
+  it('does not call onDeposit when the form is submitted with an empty amount', async () => {
+    renderDepositForm();
+    const user = userEvent.setup();
+
+    const submitButton = screen.getByRole('button', { name: /deposit/i });
+    // Button should be disabled — click should have no effect
+    await user.click(submitButton);
+
+    expect(baseProps.onDeposit).not.toHaveBeenCalled();
+  });
+});

--- a/tests/mocks/WalletContextMock.tsx
+++ b/tests/mocks/WalletContextMock.tsx
@@ -1,0 +1,121 @@
+/**
+ * WalletContextMock
+ *
+ * A lightweight test double for WalletContext that avoids the real
+ * Freighter/Albedo browser extension imports, which crash in the
+ * Jest / jsdom environment.
+ *
+ * Usage:
+ *
+ *   import { WalletContextMock, renderWithWallet } from '@/tests/mocks/WalletContextMock';
+ *
+ *   // Option 1 — use the pre-wired render helper (recommended)
+ *   const { getByRole } = renderWithWallet(<BalanceCard />);
+ *
+ *   // Option 2 — wrap manually when you need custom overrides
+ *   render(
+ *     <WalletContextMock overrides={{ isConnected: false }}>
+ *       <DepositForm ... />
+ *     </WalletContextMock>
+ *   );
+ */
+
+import React, { createContext, useContext, type ReactNode } from 'react';
+import { render, type RenderOptions } from '@testing-library/react';
+
+// ── Mirror the real context type so TypeScript catches drift ─────────────────
+// Keep this in sync with src/contexts/WalletContext.tsx → WalletContextType.
+
+type StellarNetwork = 'mainnet' | 'testnet' | 'futurenet';
+type WalletType = 'freighter' | 'albedo';
+
+interface WalletContextType {
+  address: string | null;
+  publicKey: string | null;
+  network: StellarNetwork;
+  balance: string | null;
+  isConnected: boolean;
+  isConnecting: boolean;
+  error: string | null;
+  walletType: WalletType | null;
+  connect: (walletType?: WalletType) => Promise<void>;
+  disconnect: () => void;
+}
+
+// ── Sensible connected-wallet defaults ────────────────────────────────────────
+
+export const MOCK_PUBLIC_KEY =
+  'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+
+export const DEFAULT_MOCK_WALLET: WalletContextType = {
+  address:      MOCK_PUBLIC_KEY,
+  publicKey:    MOCK_PUBLIC_KEY,
+  network:      'testnet',
+  balance:      '100.0000000',
+  isConnected:  true,
+  isConnecting: false,
+  error:        null,
+  walletType:   'freighter',
+  connect:      jest.fn().mockResolvedValue(undefined),
+  disconnect:   jest.fn(),
+};
+
+// ── Context re-export ─────────────────────────────────────────────────────────
+// We create a *separate* test context so we don't need to import the real one
+// (which drags in @stellar/freighter-api dynamic imports).
+
+const MockWalletContext = createContext<WalletContextType>(DEFAULT_MOCK_WALLET);
+
+export function useWalletContext(): WalletContextType {
+  return useContext(MockWalletContext);
+}
+
+/** @deprecated Use useWalletContext in tests */
+export const useWallet = useWalletContext;
+
+// ── Provider component ────────────────────────────────────────────────────────
+
+interface WalletContextMockProps {
+  children: ReactNode;
+  /** Selectively override any field on the default connected-wallet state. */
+  overrides?: Partial<WalletContextType>;
+}
+
+export function WalletContextMock({ children, overrides }: WalletContextMockProps) {
+  const value: WalletContextType = { ...DEFAULT_MOCK_WALLET, ...overrides };
+  return (
+    <MockWalletContext.Provider value={value}>
+      {children}
+    </MockWalletContext.Provider>
+  );
+}
+
+// ── Render helper ─────────────────────────────────────────────────────────────
+
+interface RenderWithWalletOptions extends Omit<RenderOptions, 'wrapper'> {
+  walletOverrides?: Partial<WalletContextType>;
+}
+
+/**
+ * Drop-in replacement for RTL's `render` that wraps the component in
+ * `WalletContextMock`. Accepts optional `walletOverrides` to customise state.
+ *
+ * @example
+ * const { getByRole } = renderWithWallet(<BalanceCard />, {
+ *   walletOverrides: { isConnected: false },
+ * });
+ */
+export function renderWithWallet(
+  ui: React.ReactElement,
+  { walletOverrides, ...options }: RenderWithWalletOptions = {},
+) {
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <WalletContextMock overrides={walletOverrides}>
+        {children}
+      </WalletContextMock>
+    );
+  }
+
+  return render(ui, { wrapper: Wrapper, ...options });
+}


### PR DESCRIPTION
- Add tests/mocks/WalletContextMock.tsx — standalone mock provider that avoids @stellar/freighter-api browser imports; exposes DEFAULT_MOCK_WALLET with isConnected: true, dummy publicKey, and jest.fn() for connect/disconnect; WalletContextMock accepts overrides prop; renderWithWallet is a drop-in RTL render helper
- Add tests/DepositForm.test.tsx — verifies submit button is disabled when amount is empty/zero; covers isConnected: false, isSubmitting, pending and error status messages, and that onDeposit is never called on disabled submit

Closes #97 