### PR TITLE
feat(analytics): add analytics dashboard and supporting code

### DIFF
--- a/src/components/AnalyticsMetrics.tsx
+++ b/src/components/AnalyticsMetrics.tsx
@@ -1,0 +1,96 @@
+import type { RewardPerformance, VaultParticipationMetrics } from "@/utils/contractHelpers";
+import { formatAmount } from "@/utils/contractHelpers";
+
+type AnalyticsMetricsProps = {
+  rewardPerformance: RewardPerformance;
+  participationMetrics: VaultParticipationMetrics;
+};
+
+export default function AnalyticsMetrics({
+  rewardPerformance, participationMetrics }: AnalyticsMetricsProps) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+      {/* Reward Performance Cards */}
+      <div className="bg-white dark:bg-slate-950/80 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 shadow-sm transition-all duration-300">
+        <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+          <svg className="h-5 w-5 text-axion-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          Total Rewards Earned
+        </div>
+        <div className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">
+          {formatAmount(rewardPerformance.totalRewardsEarned)}
+        </div>
+        <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+          Average rate: {rewardPerformance.averageRewardRate}%
+        </div>
+      </div>
+
+      <div className="bg-white dark:bg-slate-950/80 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 shadow-sm transition-all duration-300">
+        <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+          <svg className="h-5 w-5 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+          </svg>
+          Last Reward
+        </div>
+        <div className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">
+          {rewardPerformance.lastRewardDate 
+            ? new Date(rewardPerformance.lastRewardDate).toLocaleDateString() 
+            : "No rewards yet"}
+        </div>
+      </div>
+
+      {/* Participation Metrics Cards */}
+      <div className="bg-white dark:bg-slate-950/80 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 shadow-sm transition-all duration-300">
+        <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+          <svg className="h-5 w-5 text-blue-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+          </svg>
+          Net Deposits
+        </div>
+        <div className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">
+          {formatAmount(participationMetrics.netDeposits)}
+        </div>
+      </div>
+
+      <div className="bg-white dark:bg-slate-950/80 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 shadow-sm transition-all duration-300">
+        <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+          <svg className="h-5 w-5 text-purple-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+          </svg>
+          Active Days
+        </div>
+        <div className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">
+          {participationMetrics.activeDays}
+        </div>
+        <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+          {participationMetrics.transactionCount} total transactions
+        </div>
+      </div>
+
+      <div className="bg-white dark:bg-slate-950/80 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 shadow-sm transition-all duration-300">
+        <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+          <svg className="h-5 w-5 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          Total Deposits
+        </div>
+        <div className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">
+          {formatAmount(participationMetrics.totalDeposits)}
+        </div>
+      </div>
+
+      <div className="bg-white dark:bg-slate-950/80 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 shadow-sm transition-all duration-300">
+        <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+          <svg className="h-5 w-5 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+          </svg>
+          Total Withdrawals
+        </div>
+        <div className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">
+          {formatAmount(participationMetrics.totalWithdrawals)}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/BalanceTrendChart.tsx
+++ b/src/components/BalanceTrendChart.tsx
@@ -1,0 +1,79 @@
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend
+} from "recharts";
+import type { HistoricalBalancePoint } from "@/utils/contractHelpers";
+import { useTheme } from "@/contexts/ThemeContext";
+
+type BalanceTrendChartProps = {
+  data: HistoricalBalancePoint[];
+};
+
+export default function BalanceTrendChart({ data }: BalanceTrendChartProps) {
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
+
+  const chartData = data.map(point => ({
+    date: new Date(point.timestamp).toLocaleDateString("en-US", { month: "short", day: "numeric" }),
+    balance: Number(point.balance),
+    rewards: Number(point.rewards)
+  }));
+
+  return (
+    <div className="bg-white dark:bg-slate-950/80 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 shadow-sm transition-all duration-300">
+      <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">
+        Balance & Rewards Trend
+      </h3>
+      <div className="h-80">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={chartData} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
+            <CartesianGrid 
+              strokeDasharray="3 3" 
+              stroke={isDark ? "#334155" : "#e2e8f0"}
+            />
+            <XAxis 
+              dataKey="date" 
+              stroke={isDark ? "#94a3b8" : "#64748b"}
+            />
+            <YAxis 
+              stroke={isDark ? "#94a3b8" : "#64748b"}
+            />
+            <Tooltip 
+              contentStyle={{ 
+                backgroundColor: isDark ? "#0f172a" : "#ffffff",
+                borderColor: isDark ? "#334155" : "#e2e8f0",
+                borderRadius: "0.75rem"
+              }}
+              labelStyle={{ color: isDark ? "#f1f5f9" : "#0f172a" }}
+            />
+            <Legend />
+            <Line 
+              type="monotone" 
+              dataKey="balance" 
+              stroke="#6366f1" 
+              strokeWidth={2}
+              dot={{ r: 3 }}
+              activeDot={{ r: 5 }}
+              name="Vault Balance"
+            />
+            <Line 
+              type="monotone" 
+              dataKey="rewards" 
+              stroke="#f59e0b" 
+              strokeWidth={2}
+              dot={{ r: 3 }}
+              activeDot={{ r: 5 }}
+              name="Rewards"
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -106,6 +106,9 @@ export default function Navbar({ publicKey, isConnecting, onConnect, onDisconnec
             <Link href="/dashboard" className="rounded-lg px-3 py-2 hover:bg-slate-100 dark:hover:bg-slate-900/60">
               Vault
             </Link>
+            <Link href="/analytics" className="rounded-lg px-3 py-2 hover:bg-slate-100 dark:hover:bg-slate-900/60">
+              Analytics
+            </Link>
             <Link href="/profile" className="rounded-lg px-3 py-2 hover:bg-slate-100 dark:hover:bg-slate-900/60">
               Profile
             </Link>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -64,6 +64,15 @@ export default function Sidebar({ className = "" }: SidebarProps) {
       ),
     },
     {
+      href: "/analytics",
+      label: "Analytics",
+      icon: (
+        <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+        </svg>
+      ),
+    },
+    {
       href: "https://stellar.org/soroban",
       label: "Soroban",
       icon: (

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  createAxionveraVaultSdk,
+  type AxionveraVaultSdk,
+  type AnalyticsData
+} from "@/utils/contractHelpers";
+import { NETWORK } from "@/utils/networkConfig";
+
+type UseAnalyticsArgs = {
+  walletAddress: string | null;
+  sdk?: AxionveraVaultSdk;
+};
+
+type UseAnalyticsState = {
+  data: AnalyticsData | null;
+  isLoading: boolean;
+  error: string | null;
+};
+
+const initialState: UseAnalyticsState = {
+  data: null,
+  isLoading: false,
+  error: null
+};
+
+export function useAnalytics({ walletAddress, sdk: providedSdk }: UseAnalyticsArgs) {
+  const sdk = useMemo(() => providedSdk ?? createAxionveraVaultSdk(), [providedSdk]);
+  const [state, setState] = useState<UseAnalyticsState>(initialState);
+
+  const refresh = useCallback(async () => {
+    if (!walletAddress) {
+      setState(initialState);
+      return;
+    }
+
+    setState({ data: null, isLoading: true, error: null });
+    try {
+      const data = await sdk.getAnalytics({ walletAddress, network: NETWORK });
+      setState({ data, isLoading: false, error: null });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to load analytics data";
+      setState({ data: null, isLoading: false, error: message });
+    }
+  }, [sdk, walletAddress]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return {
+    ...state,
+    refresh
+  };
+}

--- a/src/pages/analytics.tsx
+++ b/src/pages/analytics.tsx
@@ -1,0 +1,72 @@
+import { useRouter } from "next/router";
+import { useAnalytics } from "@/hooks/useAnalytics";
+import { useWalletContext } from "@/hooks/useWallet";
+import Sidebar from "@/components/Sidebar";
+import Navbar from "@/components/Navbar";
+import AnalyticsMetrics from "@/components/AnalyticsMetrics";
+import BalanceTrendChart from "@/components/BalanceTrendChart";
+import { Skeletons } from "@/components/Skeletons";
+import { useEffect } from "react";
+
+export default function AnalyticsPage() {
+  const wallet = useWalletContext();
+  const router = useRouter();
+  const analytics = useAnalytics({ walletAddress: wallet.publicKey });
+
+  useEffect(() => {
+    if (!wallet.isConnected && !wallet.isConnecting) {
+      router.replace("/");
+    }
+  }, [wallet.isConnected, wallet.isConnecting, router]);
+
+  return (
+    <>
+      <main className="min-h-screen bg-background-primary text-text-primary transition-colors duration-200">
+        <Sidebar />
+        <div className="flex-1 lg:pl-64 w-full transition-all">
+          <Navbar
+            publicKey={wallet.publicKey}
+            isConnecting={wallet.isConnecting}
+            onConnect={wallet.connect}
+            onDisconnect={wallet.disconnect}
+          />
+          <div className="mx-auto max-w-6xl px-4 sm:px-6 py-6 md:py-8 w-full">
+            <h1 className="text-3xl font-bold text-slate-900 dark:text-white mb-2">
+              Portfolio Analytics
+            </h1>
+            <p className="text-slate-600 dark:text-slate-300 mb-8">
+              Track your vault performance and historical trends
+            </p>
+
+            {analytics.isLoading ? (
+              <div className="space-y-6">
+                <Skeletons />
+                <div className="h-80 bg-slate-100 dark:bg-slate-800/50 rounded-2xl animate-pulse" />
+              </div>
+            ) : analytics.error ? (
+              <div className="p-8 rounded-2xl border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/30">
+                <p className="text-red-600 dark:text-red-300 text-center">{analytics.error}</p>
+                <button
+                  onClick={() => analytics.refresh()}
+                  className="mt-4 w-full max-w-xs mx-auto block bg-red-600 text-white px-4 py-2 rounded-xl"
+                >
+                  Try Again
+                </button>
+              </div>
+            ) : analytics.data ? (
+              <>
+                <AnalyticsMetrics
+                  rewardPerformance={analytics.data.rewardPerformance}
+                  participationMetrics={analytics.data.participationMetrics}
+                />
+                <div className="mt-8">
+                  <BalanceTrendChart data={analytics.data.historicalBalances} />
+                </div>
+              </>
+            ) : null}
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/utils/contractHelpers.ts
+++ b/src/utils/contractHelpers.ts
@@ -19,12 +19,41 @@ export type VaultBalances = {
   rewards: string;
 };
 
+export type HistoricalBalancePoint = {
+  timestamp: string;
+  balance: string;
+  rewards: string;
+};
+
+export type RewardPerformance = {
+  totalRewardsEarned: string;
+  averageRewardRate: string; // percentage
+  lastRewardDate: string | null;
+};
+
+export type VaultParticipationMetrics = {
+  totalDeposits: string;
+  totalWithdrawals: string;
+  netDeposits: string;
+  transactionCount: number;
+  firstInteractionDate: string | null;
+  lastInteractionDate: string | null;
+  activeDays: number;
+};
+
+export type AnalyticsData = {
+  historicalBalances: HistoricalBalancePoint[];
+  rewardPerformance: RewardPerformance;
+  participationMetrics: VaultParticipationMetrics;
+};
+
 export type AxionveraVaultSdk = {
   getBalances: (args: { walletAddress: string; network: StellarNetwork }, options?: ApiCallOptions) => Promise<VaultBalances>;
   getTransactions: (args: { walletAddress: string; network: StellarNetwork }, options?: ApiCallOptions) => Promise<VaultTx[]>;
   deposit: (args: { walletAddress: string; network: StellarNetwork; amount: string }, options?: ApiCallOptions) => Promise<VaultTx>;
   withdraw: (args: { walletAddress: string; network: StellarNetwork; amount: string }, options?: ApiCallOptions) => Promise<VaultTx>;
   claimRewards: (args: { walletAddress: string; network: StellarNetwork }, options?: ApiCallOptions) => Promise<VaultTx>;
+  getAnalytics: (args: { walletAddress: string; network: StellarNetwork }, options?: ApiCallOptions) => Promise<AnalyticsData>;
 };
 
 export function shortenAddress(address: string, chars = 6) {
@@ -179,6 +208,90 @@ export function createAxionveraVaultSdk(): AxionveraVaultSdk {
       };
       saveVault(walletAddress, network, next);
       return completed;
+    },
+    async getAnalytics({ walletAddress, network }: { walletAddress: string; network: StellarNetwork }) {
+      await sleep(200);
+      const vault = loadVault(walletAddress, network);
+      const txs = vault.txs.filter(tx => tx.status === "success");
+      
+      // Generate historical balances (last 30 days)
+      const historicalBalances: HistoricalBalancePoint[] = [];
+      let currentBalance = 0;
+      let currentRewards = 0;
+      const now = new Date();
+      
+      for (let i = 30; i >= 0; i--) {
+        const date = new Date(now);
+        date.setDate(date.getDate() - i);
+        const timestamp = date.toISOString();
+        
+        // Simulate balance changes based on transactions
+        const txsOnDay = txs.filter(tx => {
+          const txDate = new Date(tx.createdAt);
+          return txDate.toDateString() === date.toDateString();
+        });
+        
+        txsOnDay.forEach(tx => {
+          if (tx.type === "deposit") {
+            currentBalance += Number(tx.amount);
+            currentRewards += Number(tx.amount) * 0.01;
+          } else if (tx.type === "withdraw") {
+            currentBalance = Math.max(0, currentBalance - Number(tx.amount));
+          } else if (tx.type === "claim") {
+            currentBalance += currentRewards;
+            currentRewards = 0;
+          }
+        });
+        
+        historicalBalances.push({
+          timestamp,
+          balance: toFixedString(currentBalance),
+          rewards: toFixedString(currentRewards)
+        });
+      }
+      
+      // Calculate reward performance
+      const claimTxs = txs.filter(tx => tx.type === "claim");
+      const totalRewardsEarned = claimTxs.reduce((sum, tx) => sum + Number(tx.amount), 0);
+      const lastClaimTx = claimTxs.length > 0 ? claimTxs[0] : null;
+      const averageRewardRate = totalRewardsEarned > 0 ? "1.0" : "0"; // 1% mock rate
+      
+      // Calculate participation metrics
+      const depositTxs = txs.filter(tx => tx.type === "deposit");
+      const withdrawTxs = txs.filter(tx => tx.type === "withdraw");
+      const totalDeposits = depositTxs.reduce((sum, tx) => sum + Number(tx.amount), 0);
+      const totalWithdrawals = withdrawTxs.reduce((sum, tx) => sum + Number(tx.amount), 0);
+      const netDeposits = totalDeposits - totalWithdrawals;
+      const transactionCount = txs.length;
+      
+      const firstInteractionDate = txs.length > 0 ? txs[txs.length - 1].createdAt : null;
+      const lastInteractionDate = txs.length > 0 ? txs[0].createdAt : null;
+      
+      // Calculate active days
+      const activeDaysSet = new Set<string>();
+      txs.forEach(tx => {
+        const date = new Date(tx.createdAt).toDateString();
+        activeDaysSet.add(date);
+      });
+      const activeDays = activeDaysSet.size;
+      
+      return {
+        historicalBalances,
+        rewardPerformance: {
+          totalRewardsEarned: toFixedString(totalRewardsEarned),
+          averageRewardRate,
+          lastRewardDate: lastClaimTx ? lastClaimTx.createdAt : null
+        },
+        participationMetrics: {
+          totalDeposits: toFixedString(totalDeposits),
+          totalWithdrawals: toFixedString(totalWithdrawals),
+          netDeposits: toFixedString(netDeposits),
+          transactionCount,
+          firstInteractionDate,
+          lastInteractionDate,
+          activeDays
+        }
+      };
     }
   };
 
@@ -203,6 +316,10 @@ export function createAxionveraVaultSdk(): AxionveraVaultSdk {
     claimRewards: withErrorHandling(
       withApiResilience(baseSdk.claimRewards, { timeout: 10000, retries: 1 }),
       'claimRewards'
+    ),
+    getAnalytics: withErrorHandling(
+      withApiResilience(baseSdk.getAnalytics, { timeout: 5000, retries: 2 }),
+      'getAnalytics'
     )
   };
 }


### PR DESCRIPTION
Closes #208 
Add Analytics navigation links to the Navbar and Sidebar, implement the useAnalytics custom hook for fetching and managing analytics data, build the full analytics page with loading, error, and success states. Also add supporting UI components including AnalyticsMetrics and BalanceTrendChart, and extend the vault SDK with analytics data types and endpoint handling.