### PR TITLE
feat: implement transaction simulation workflow (#210)

### DIFF
--- a/src/components/DepositForm.tsx
+++ b/src/components/DepositForm.tsx
@@ -6,6 +6,8 @@ import { notify } from '@/utils/notifications';
 import { shortenAddress } from '@/utils/contractHelpers';
 import { AppTooltip } from './AppTooltip';
 import { GLOSSARY } from '@/utils/glossary';
+import { useTransactionSimulation } from '@/hooks/useTransactionSimulation';
+import { TransactionSimulationPreview } from './TransactionSimulationPreview';
 
 type DepositFormProps = {
   isConnected: boolean;
@@ -14,6 +16,7 @@ type DepositFormProps = {
   status: "idle" | "pending" | "success" | "error";
   statusMessage?: string | null;
   transactionHash?: string | null;
+  walletAddress?: string | null;
   walletBalance?: number | null;
 };
 
@@ -26,6 +29,7 @@ export default function DepositForm({
   status,
   statusMessage,
   transactionHash,
+  walletAddress,
   walletBalance,
 }: DepositFormProps) {
   const {
@@ -33,14 +37,16 @@ export default function DepositForm({
     handleSubmit,
     reset,
     setValue,
+    getValues,
     formState: { isValid, isDirty }
   } = useForm<DepositFormData>({
     resolver: zodResolver(depositSchema),
     mode: 'onChange',
-    defaultValues: {
-      amount: '' as any,
-    }
+    defaultValues: { amount: '' as any }
   });
+
+  const { simulationStatus, simulationResult, simulationError, simulate, resetSimulation } =
+    useTransactionSimulation(walletAddress ?? null);
 
   const spendableBalance =
     walletBalance !== undefined && walletBalance !== null
@@ -49,134 +55,137 @@ export default function DepositForm({
 
   function handleMax() {
     if (spendableBalance !== null && spendableBalance > 0) {
-      setValue('amount', spendableBalance as any, {
-        shouldValidate: true,
-        shouldDirty: true,
-      });
+      setValue('amount', spendableBalance as any, { shouldValidate: true, shouldDirty: true });
     }
   }
 
   const onSubmit = async (data: DepositFormData) => {
+    await simulate("deposit", data.amount.toString());
+  };
+
+  const handleConfirm = async () => {
+    const amount = getValues('amount');
     try {
-      await onDeposit(data.amount.toString());
-      notify.success("Deposit Successful", `You have deposited ${data.amount} tokens.`);
+      await onDeposit(amount.toString());
+      notify.success("Deposit Successful", `You have deposited ${amount} tokens.`);
       reset();
     } catch (error) {
       console.error('Deposit error:', error);
+    } finally {
+      resetSimulation();
     }
   };
 
-  const shouldDisableSubmit = !isConnected || !isValid || !isDirty || isSubmitting;
+  const shouldDisableSubmit = !isConnected || !isValid || !isDirty || isSubmitting || simulationStatus === 'loading';
 
   return (
-    <section className="rounded-2xl border border-border-primary bg-background-primary/30 p-6">
-      <div className="text-sm font-semibold text-text-primary">Deposit</div>
-      <div className="mt-1 text-xs text-text-muted">Deposit tokens into the Axionvera vault.</div>
-
-      <form onSubmit={handleSubmit(onSubmit)} className="mt-5 space-y-4">
-
-        <div className="flex items-center justify-between text-xs text-text-muted">
-          <span>Available Balance</span>
-          <div className="flex items-center gap-2">
-            <span className="font-medium text-text-primary">
-              {spendableBalance !== null ? `${spendableBalance.toFixed(4)} XLM` : '—'}
-            </span>
-            <button
-              type="button"
-              onClick={handleMax}
-              disabled={!isConnected || spendableBalance === null || spendableBalance <= 0}
-              className="rounded-md bg-axion-500/10 px-2 py-0.5 text-xs font-semibold text-axion-400 transition hover:bg-axion-500/20 disabled:cursor-not-allowed disabled:opacity-40"
-            >
-              Max
-            </button>
-          </div>
-        </div>
-
-        <FormInput
-          {...register('amount')}
-          id="deposit-amount"
-          inputMode="decimal"
-          placeholder="0.0"
-          label="Amount"
-          required
-          helperText={
-            <span>
-              Enter amount between 0.0001 and 10,000{' '}
-              <AppTooltip content={GLOSSARY.slippage}>
-                <span className="cursor-help font-semibold uppercase tracking-wider text-axion-500 underline decoration-dotted decoration-axion-500/50 underline-offset-2 transition-colors hover:text-axion-400">
-                  Slippage
-                </span>
-              </AppTooltip>
-            </span>
-          }
+    <>
+      {simulationResult && (
+        <TransactionSimulationPreview
+          result={simulationResult}
+          isSubmitting={isSubmitting}
+          onConfirm={handleConfirm}
+          onCancel={resetSimulation}
         />
+      )}
 
-        {status !== 'idle' ? (
-          <div
-            role="status"
-            aria-live="polite"
-            className={`rounded-xl border px-4 py-3 text-sm ${
-              status === 'success'
-                ? 'border-emerald-900/50 bg-emerald-950/30 text-emerald-200'
-                : status === 'error'
-                  ? 'border-rose-900/50 bg-rose-950/30 text-rose-200'
-                  : 'border-border-primary bg-background-secondary/30 text-text-primary'
-            }`}
-          >
-            <div className="font-medium">
-              {status === 'pending'
-                ? 'Deposit transaction pending'
-                : status === 'success'
-                  ? 'Deposit completed'
-                  : 'Deposit failed'}
-            </div>
-            {statusMessage ? (
-              <div className="mt-1 text-xs opacity-90">{statusMessage}</div>
-            ) : null}
-            {transactionHash ? (
-              <div className="mt-1 text-xs opacity-80">
-                Tx: {shortenAddress(transactionHash, 8)}
-              </div>
-            ) : null}
-          </div>
-        ) : null}
+      <section className="rounded-2xl border border-border-primary bg-background-primary/30 p-6">
+        <div className="text-sm font-semibold text-text-primary">Deposit</div>
+        <div className="mt-1 text-xs text-text-muted">Deposit tokens into the Axionvera vault.</div>
 
-        <button
-          type="submit"
-          disabled={shouldDisableSubmit}
-          aria-label={isSubmitting ? "Submitting deposit" : "Deposit tokens"}
-          className="flex w-full items-center justify-center gap-2 rounded-xl bg-axion-500 px-4 py-3 text-sm font-medium text-white shadow-lg shadow-axion-500/20 transition hover:bg-axion-400 disabled:cursor-not-allowed disabled:opacity-70"
-        >
-          {isSubmitting ? (
-            <>
-              <svg
-                className="h-4 w-4 animate-spin"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
+        <form onSubmit={handleSubmit(onSubmit)} className="mt-5 space-y-4">
+          <div className="flex items-center justify-between text-xs text-text-muted">
+            <span>Available Balance</span>
+            <div className="flex items-center gap-2">
+              <span className="font-medium text-text-primary">
+                {spendableBalance !== null ? `${spendableBalance.toFixed(4)} XLM` : '—'}
+              </span>
+              <button
+                type="button"
+                onClick={handleMax}
+                disabled={!isConnected || spendableBalance === null || spendableBalance <= 0}
+                className="rounded-md bg-axion-500/10 px-2 py-0.5 text-xs font-semibold text-axion-400 transition hover:bg-axion-500/20 disabled:cursor-not-allowed disabled:opacity-40"
               >
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                />
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-                />
-              </svg>
-              Depositing...
-            </>
-          ) : (
-            "Deposit"
+                Max
+              </button>
+            </div>
+          </div>
+
+          <FormInput
+            {...register('amount')}
+            id="deposit-amount"
+            inputMode="decimal"
+            placeholder="0.0"
+            label="Amount"
+            required
+            helperText={
+              <span>
+                Enter amount between 0.0001 and 10,000{' '}
+                <AppTooltip content={GLOSSARY.slippage}>
+                  <span className="cursor-help font-semibold uppercase tracking-wider text-axion-500 underline decoration-dotted decoration-axion-500/50 underline-offset-2 transition-colors hover:text-axion-400">
+                    Slippage
+                  </span>
+                </AppTooltip>
+              </span>
+            }
+          />
+
+          {simulationError && (
+            <div role="alert" className="rounded-xl border border-rose-900/50 bg-rose-950/30 px-4 py-3 text-xs text-rose-200">
+              {simulationError}
+            </div>
           )}
-        </button>
-      </form>
-    </section>
+
+          {status !== 'idle' ? (
+            <div
+              role="status"
+              aria-live="polite"
+              className={`rounded-xl border px-4 py-3 text-sm ${
+                status === 'success'
+                  ? 'border-emerald-900/50 bg-emerald-950/30 text-emerald-200'
+                  : status === 'error'
+                    ? 'border-rose-900/50 bg-rose-950/30 text-rose-200'
+                    : 'border-border-primary bg-background-secondary/30 text-text-primary'
+              }`}
+            >
+              <div className="font-medium">
+                {status === 'pending' ? 'Deposit transaction pending' : status === 'success' ? 'Deposit completed' : 'Deposit failed'}
+              </div>
+              {statusMessage ? <div className="mt-1 text-xs opacity-90">{statusMessage}</div> : null}
+              {transactionHash ? (
+                <div className="mt-1 text-xs opacity-80">Tx: {shortenAddress(transactionHash, 8)}</div>
+              ) : null}
+            </div>
+          ) : null}
+
+          <button
+            type="submit"
+            disabled={shouldDisableSubmit}
+            aria-label={simulationStatus === 'loading' ? "Simulating transaction" : isSubmitting ? "Submitting deposit" : "Preview deposit"}
+            className="flex w-full items-center justify-center gap-2 rounded-xl bg-axion-500 px-4 py-3 text-sm font-medium text-white shadow-lg shadow-axion-500/20 transition hover:bg-axion-400 disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {simulationStatus === 'loading' ? (
+              <>
+                <svg className="h-4 w-4 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                Simulating...
+              </>
+            ) : isSubmitting ? (
+              <>
+                <svg className="h-4 w-4 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                Depositing...
+              </>
+            ) : (
+              "Preview Deposit"
+            )}
+          </button>
+        </form>
+      </section>
+    </>
   );
 }

--- a/src/components/TransactionSimulationPreview.tsx
+++ b/src/components/TransactionSimulationPreview.tsx
@@ -1,0 +1,67 @@
+import { formatAmount } from "@/utils/contractHelpers";
+import type { SimulationResult } from "@/hooks/useTransactionSimulation";
+
+type TransactionSimulationPreviewProps = {
+  result: SimulationResult;
+  isSubmitting: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+function Row({ label, value, highlight }: { label: string; value: string; highlight?: "positive" | "negative" | "neutral" }) {
+  const valueClass = highlight === "positive" ? "text-emerald-400" : highlight === "negative" ? "text-rose-400" : "text-text-primary";
+  return (
+    <div className="flex items-center justify-between py-2 text-xs">
+      <span className="text-text-muted">{label}</span>
+      <span className={`font-medium ${valueClass}`}>{value}</span>
+    </div>
+  );
+}
+
+export function TransactionSimulationPreview({ result, isSubmitting, onConfirm, onCancel }: TransactionSimulationPreviewProps) {
+  const isDeposit = result.type === "deposit";
+  const netChange = parseFloat(result.netChange);
+  return (
+    <div role="dialog" aria-modal="true" aria-label="Transaction preview" className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4 backdrop-blur-sm">
+      <div className="w-full max-w-sm rounded-2xl border border-border-primary bg-background-primary p-6 shadow-2xl">
+        <div className="mb-4 flex items-center gap-3">
+          <div className={`flex h-9 w-9 items-center justify-center rounded-full ${isDeposit ? "bg-axion-500/15" : "bg-amber-500/15"}`}>
+            <svg className={`h-4 w-4 ${isDeposit ? "text-axion-400" : "text-amber-400"}`} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              {isDeposit ? <path d="M12 5v14M5 12l7 7 7-7" /> : <path d="M12 19V5M5 12l7-7 7 7" />}
+            </svg>
+          </div>
+          <div>
+            <div className="text-sm font-semibold text-text-primary">Preview {isDeposit ? "Deposit" : "Withdrawal"}</div>
+            <div className="text-xs text-text-muted">Review before confirming</div>
+          </div>
+        </div>
+        <div className={`mb-4 rounded-xl border px-4 py-3 text-center ${isDeposit ? "border-axion-500/30 bg-axion-500/10" : "border-amber-500/30 bg-amber-500/10"}`}>
+          <div className="text-xs text-text-muted">Amount</div>
+          <div className={`mt-0.5 text-2xl font-bold ${isDeposit ? "text-axion-400" : "text-amber-400"}`}>
+            {netChange > 0 ? "+" : ""}{formatAmount(result.netChange)} XLM
+          </div>
+        </div>
+        <div className="divide-y divide-border-primary/50 rounded-xl border border-border-primary bg-background-secondary/20 px-4">
+          <Row label="Current Balance" value={`${formatAmount(result.currentBalance)} XLM`} />
+          <Row label="Projected Balance" value={`${formatAmount(result.projectedBalance)} XLM`} highlight={isDeposit ? "positive" : "neutral"} />
+          {isDeposit && <Row label="Projected Rewards" value={`${formatAmount(result.projectedRewards)} XLM`} highlight="positive" />}
+          <Row label="Estimated Network Fee" value={`~${result.estimatedFee} XLM`} />
+        </div>
+        <p className="mt-3 text-center text-[11px] text-text-muted">This is a simulation. Actual results may vary slightly.</p>
+        <div className="mt-4 flex gap-3">
+          <button type="button" onClick={onCancel} disabled={isSubmitting} className="flex-1 rounded-xl border border-border-primary bg-background-secondary/30 px-4 py-2.5 text-sm font-medium text-text-primary transition hover:bg-background-secondary/60 disabled:cursor-not-allowed disabled:opacity-50">
+            Cancel
+          </button>
+          <button type="button" onClick={onConfirm} disabled={isSubmitting} aria-label={isSubmitting ? "Processing transaction" : `Confirm ${result.type}`} className={`flex flex-1 items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-medium text-white shadow-lg transition disabled:cursor-not-allowed disabled:opacity-70 ${isDeposit ? "bg-axion-500 shadow-axion-500/20 hover:bg-axion-400" : "bg-amber-500 shadow-amber-500/20 hover:bg-amber-400"}`}>
+            {isSubmitting ? (
+              <svg className="h-4 w-4 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              </svg>
+            ) : (`Confirm ${isDeposit ? "Deposit" : "Withdrawal"}`)}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/WithdrawForm.tsx
+++ b/src/components/WithdrawForm.tsx
@@ -4,6 +4,8 @@ import { FormInput } from './FormInput';
 import { createWithdrawSchema, WithdrawFormData } from '@/utils/validation';
 import { notify } from '@/utils/notifications';
 import { formatAmount, shortenAddress } from '@/utils/contractHelpers';
+import { useTransactionSimulation } from '@/hooks/useTransactionSimulation';
+import { TransactionSimulationPreview } from './TransactionSimulationPreview';
 
 type WithdrawFormProps = {
   isConnected: boolean;
@@ -13,6 +15,7 @@ type WithdrawFormProps = {
   status: "idle" | "pending" | "success" | "error";
   statusMessage?: string | null;
   transactionHash?: string | null;
+  walletAddress?: string | null;
 };
 
 export default function WithdrawForm({
@@ -22,84 +25,111 @@ export default function WithdrawForm({
   onWithdraw,
   status,
   statusMessage,
-  transactionHash
+  transactionHash,
+  walletAddress,
 }: WithdrawFormProps) {
   const {
     register,
     handleSubmit,
     reset,
+    getValues,
     formState: { errors, isValid, isDirty }
   } = useForm<WithdrawFormData>({
     resolver: zodResolver(createWithdrawSchema(parseFloat(balance))),
     mode: 'onChange',
-    defaultValues: {
-      amount: '' as any,
-    }
+    defaultValues: { amount: '' as any }
   });
 
+  const { simulationStatus, simulationResult, simulationError, simulate, resetSimulation } =
+    useTransactionSimulation(walletAddress ?? null);
+
   const onSubmit = async (data: WithdrawFormData) => {
+    await simulate("withdraw", data.amount.toString());
+  };
+
+  const handleConfirm = async () => {
+    const amount = getValues('amount');
     try {
-      await onWithdraw(data.amount.toString());
-      notify.success("Withdrawal Successful", `You have withdrawn ${data.amount} tokens.`);
+      await onWithdraw(amount.toString());
+      notify.success("Withdrawal Successful", `You have withdrawn ${amount} tokens.`);
       reset();
     } catch (error) {
       console.error('Withdrawal error:', error);
+    } finally {
+      resetSimulation();
     }
   };
 
-  const shouldDisableSubmit = !isConnected || !isValid || !isDirty || isSubmitting;
+  const shouldDisableSubmit = !isConnected || !isValid || !isDirty || isSubmitting || simulationStatus === 'loading';
 
   return (
-    <section className="rounded-2xl border border-border-primary bg-background-primary/30 p-6">
-      <div className="text-sm font-semibold text-text-primary">Withdraw</div>
-      <div className="mt-1 text-xs text-text-muted">Withdraw tokens from the Axionvera vault.</div>
-      <div className="mt-3 rounded-xl border border-border-primary bg-background-secondary/20 px-4 py-3 text-xs text-text-secondary">
-        Available balance: <span className="font-medium text-text-primary">{formatAmount(balance)}</span>
-      </div>
-
-      <form onSubmit={handleSubmit(onSubmit)} className="mt-5 space-y-4">
-        <FormInput
-          {...register('amount')}
-          id="withdraw-amount"
-          inputMode="decimal"
-          placeholder="0.0"
-          label="Amount"
-          required
-          error={errors.amount}
-          helperText={`Enter amount between 0.0001 and ${formatAmount(balance)}`}
+    <>
+      {simulationResult && (
+        <TransactionSimulationPreview
+          result={simulationResult}
+          isSubmitting={isSubmitting}
+          onConfirm={handleConfirm}
+          onCancel={resetSimulation}
         />
+      )}
 
-        {status !== 'idle' ? (
-          <div
-            role="status"
-            aria-live="polite"
-            className={`rounded-xl border px-4 py-3 text-sm ${
-              status === 'success'
-                ? 'border-emerald-900/50 bg-emerald-950/30 text-emerald-200'
-                : status === 'error'
-                  ? 'border-rose-900/50 bg-rose-950/30 text-rose-200'
-                  : 'border-border-primary bg-background-secondary/30 text-text-primary'
-            }`}
-          >
-            <div className="font-medium">
-              {status === 'pending' ? 'Withdrawal transaction pending' : status === 'success' ? 'Withdrawal completed' : 'Withdrawal failed'}
+      <section className="rounded-2xl border border-border-primary bg-background-primary/30 p-6">
+        <div className="text-sm font-semibold text-text-primary">Withdraw</div>
+        <div className="mt-1 text-xs text-text-muted">Withdraw tokens from the Axionvera vault.</div>
+        <div className="mt-3 rounded-xl border border-border-primary bg-background-secondary/20 px-4 py-3 text-xs text-text-secondary">
+          Available balance: <span className="font-medium text-text-primary">{formatAmount(balance)}</span>
+        </div>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="mt-5 space-y-4">
+          <FormInput
+            {...register('amount')}
+            id="withdraw-amount"
+            inputMode="decimal"
+            placeholder="0.0"
+            label="Amount"
+            required
+            error={errors.amount}
+            helperText={`Enter amount between 0.0001 and ${formatAmount(balance)}`}
+          />
+
+          {simulationError && (
+            <div role="alert" className="rounded-xl border border-rose-900/50 bg-rose-950/30 px-4 py-3 text-xs text-rose-200">
+              {simulationError}
             </div>
-            {statusMessage ? <div className="mt-1 text-xs opacity-90">{statusMessage}</div> : null}
-            {transactionHash ? (
-              <div className="mt-1 text-xs opacity-80">Tx: {shortenAddress(transactionHash, 8)}</div>
-            ) : null}
-          </div>
-        ) : null}
+          )}
 
-        <button
-          type="submit"
-          disabled={shouldDisableSubmit}
-          aria-label={isSubmitting ? "Submitting withdrawal" : "Withdraw tokens"}
-          className="w-full rounded-xl border border-border-primary bg-background-secondary/30 px-4 py-3 text-sm font-medium text-text-primary transition hover:bg-background-secondary/60 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {isSubmitting ? "Submitting..." : "Withdraw"}
-        </button>
-      </form>
-    </section>
+          {status !== 'idle' ? (
+            <div
+              role="status"
+              aria-live="polite"
+              className={`rounded-xl border px-4 py-3 text-sm ${
+                status === 'success'
+                  ? 'border-emerald-900/50 bg-emerald-950/30 text-emerald-200'
+                  : status === 'error'
+                    ? 'border-rose-900/50 bg-rose-950/30 text-rose-200'
+                    : 'border-border-primary bg-background-secondary/30 text-text-primary'
+              }`}
+            >
+              <div className="font-medium">
+                {status === 'pending' ? 'Withdrawal transaction pending' : status === 'success' ? 'Withdrawal completed' : 'Withdrawal failed'}
+              </div>
+              {statusMessage ? <div className="mt-1 text-xs opacity-90">{statusMessage}</div> : null}
+              {transactionHash ? (
+                <div className="mt-1 text-xs opacity-80">Tx: {shortenAddress(transactionHash, 8)}</div>
+              ) : null}
+            </div>
+          ) : null}
+
+          <button
+            type="submit"
+            disabled={shouldDisableSubmit}
+            aria-label={simulationStatus === 'loading' ? "Simulating transaction" : isSubmitting ? "Submitting withdrawal" : "Preview withdrawal"}
+            className="w-full rounded-xl border border-border-primary bg-background-secondary/30 px-4 py-3 text-sm font-medium text-text-primary transition hover:bg-background-secondary/60 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {simulationStatus === 'loading' ? 'Simulating...' : isSubmitting ? 'Submitting...' : 'Preview Withdrawal'}
+          </button>
+        </form>
+      </section>
+    </>
   );
 }

--- a/src/hooks/useTransactionSimulation.ts
+++ b/src/hooks/useTransactionSimulation.ts
@@ -1,0 +1,109 @@
+import { useCallback, useState } from "react";
+import { createAxionveraVaultSdk, formatAmount } from "@/utils/contractHelpers";
+import { NETWORK } from "@/utils/networkConfig";
+
+export type SimulationResult = {
+  type: "deposit" | "withdraw";
+  amount: string;
+  currentBalance: string;
+  projectedBalance: string;
+  projectedRewards: string;
+  estimatedFee: string;
+  netChange: string;
+};
+
+type SimulationState = {
+  status: "idle" | "loading" | "ready" | "error";
+  result: SimulationResult | null;
+  error: string | null;
+};
+
+const INITIAL_STATE: SimulationState = {
+  status: "idle",
+  result: null,
+  error: null,
+};
+
+const ESTIMATED_NETWORK_FEE = "0.00001";
+const DEPOSIT_REWARD_RATE = 0.01;
+
+export function useTransactionSimulation(walletAddress: string | null) {
+  const [state, setState] = useState<SimulationState>(INITIAL_STATE);
+  const sdk = createAxionveraVaultSdk();
+
+  const simulate = useCallback(
+    async (type: "deposit" | "withdraw", amountInput: string) => {
+      if (!walletAddress) {
+        setState({ status: "error", result: null, error: "Wallet not connected." });
+        return;
+      }
+
+      const amount = parseFloat(amountInput);
+      if (!Number.isFinite(amount) || amount <= 0) {
+        setState({ status: "error", result: null, error: "Enter a valid amount." });
+        return;
+      }
+
+      setState({ status: "loading", result: null, error: null });
+
+      try {
+        const balances = await sdk.getBalances({ walletAddress, network: NETWORK });
+        const currentBalance = parseFloat(balances.balance);
+        const currentRewards = parseFloat(balances.rewards);
+
+        let projectedBalance: number;
+        let projectedRewards: number;
+        let netChange: number;
+
+        if (type === "deposit") {
+          projectedBalance = currentBalance + amount;
+          projectedRewards = currentRewards + amount * DEPOSIT_REWARD_RATE;
+          netChange = amount;
+        } else {
+          if (amount > currentBalance) {
+            setState({
+              status: "error",
+              result: null,
+              error: `Insufficient balance. Available: ${formatAmount(balances.balance)} XLM`,
+            });
+            return;
+          }
+          projectedBalance = Math.max(0, currentBalance - amount);
+          projectedRewards = currentRewards;
+          netChange = -amount;
+        }
+
+        setState({
+          status: "ready",
+          error: null,
+          result: {
+            type,
+            amount: amountInput,
+            currentBalance: balances.balance,
+            projectedBalance: projectedBalance.toString(),
+            projectedRewards: projectedRewards.toString(),
+            estimatedFee: ESTIMATED_NETWORK_FEE,
+            netChange: netChange.toString(),
+          },
+        });
+      } catch (err) {
+        setState({
+          status: "error",
+          result: null,
+          error: err instanceof Error ? err.message : "Simulation failed.",
+        });
+      }
+    },
+    [walletAddress, sdk]
+  );
+
+  const reset = useCallback(() => setState(INITIAL_STATE), []);
+
+  return {
+    simulationStatus: state.status,
+    simulationResult: state.result,
+    simulationError: state.error,
+    simulate,
+    resetSimulation: reset,
+  };
+}

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -62,6 +62,7 @@ export default function DashboardPage() {
                     onDeposit={vault.deposit}
                     status={vault.depositStatus}
                     walletBalance={wallet.balance ? parseFloat(wallet.balance) : null}
+                    walletAddress={wallet.publicKey}
 
                     statusMessage={
                       vault.depositStatus === "pending"
@@ -90,6 +91,7 @@ export default function DashboardPage() {
                             : null
                     }
                     transactionHash={vault.withdrawHash}
+                    walletAddress={wallet.publicKey}
                   />
                 </div>
                 <div className="mt-6 w-full overflow-x-auto">


### PR DESCRIPTION
Closes #210 

- Add useTransactionSimulation hook to preview deposit/withdraw outcomes
- Add TransactionSimulationPreview modal with projected balance and fees
- Update DepositForm to show simulation preview before submitting
- Update WithdrawForm to show simulation preview before submitting
- Pass walletAddress prop through dashboard to both forms