### PR TITLE
feat: add governance dashboard

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -73,6 +73,15 @@ export default function Sidebar({ className = "" }: SidebarProps) {
       ),
     },
     {
+      href: "/governance",
+      label: "Governance",
+      icon: (
+        <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h6m-6 4h6M8 8h8m-9 12h10a2 2 0 002-2V6.5L14.5 2H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
+        </svg>
+      ),
+    },
+    {
       href: "https://stellar.org/soroban",
       label: "Soroban",
       icon: (

--- a/src/features/governance/GovernanceDashboard.tsx
+++ b/src/features/governance/GovernanceDashboard.tsx
@@ -1,0 +1,203 @@
+import { useMemo, useState } from "react";
+
+import { castGovernanceVote, formatGovernancePercent, getProposalTally } from "./governanceModel";
+import { initialGovernanceProposals } from "./proposals";
+import type { GovernanceProposal, VoteChoice } from "./types";
+
+const voteLabels: Record<VoteChoice, string> = {
+  for: "Support",
+  against: "Against",
+  abstain: "Abstain"
+};
+
+const voteButtonClasses: Record<VoteChoice, string> = {
+  for: "border-emerald-500 bg-emerald-50 text-emerald-700 hover:bg-emerald-100 dark:bg-emerald-950/30 dark:text-emerald-200",
+  against: "border-rose-500 bg-rose-50 text-rose-700 hover:bg-rose-100 dark:bg-rose-950/30 dark:text-rose-200",
+  abstain: "border-slate-400 bg-slate-50 text-slate-700 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-200"
+};
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+function StatCard({ label, value, detail }: { label: string; value: string; detail: string }) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-950/80">
+      <div className="text-sm text-slate-500 dark:text-slate-400">{label}</div>
+      <div className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">{value}</div>
+      <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">{detail}</div>
+    </div>
+  );
+}
+
+export default function GovernanceDashboard() {
+  const [proposals, setProposals] = useState<GovernanceProposal[]>(initialGovernanceProposals);
+  const [selectedProposalId, setSelectedProposalId] = useState(initialGovernanceProposals[0]?.id ?? "");
+  const [votesByProposal, setVotesByProposal] = useState<Record<string, VoteChoice>>({});
+
+  const selectedProposal = proposals.find((proposal) => proposal.id === selectedProposalId) ?? proposals[0];
+  const selectedVote = selectedProposal ? votesByProposal[selectedProposal.id] : undefined;
+  const selectedTally = selectedProposal ? getProposalTally(selectedProposal) : null;
+
+  const governanceSummary = useMemo(() => {
+    const active = proposals.filter((proposal) => proposal.state === "active").length;
+    const totalVotes = proposals.reduce((sum, proposal) => sum + getProposalTally(proposal).totalVotes, 0);
+    const quorumReached = proposals.filter((proposal) => getProposalTally(proposal).quorumReached).length;
+
+    return { active, totalVotes, quorumReached };
+  }, [proposals]);
+
+  function handleVote(choice: VoteChoice) {
+    if (!selectedProposal) return;
+
+    setProposals((current) =>
+      current.map((proposal) =>
+        proposal.id === selectedProposal.id
+          ? castGovernanceVote(proposal, choice, votesByProposal[proposal.id])
+          : proposal
+      )
+    );
+    setVotesByProposal((current) => ({ ...current, [selectedProposal.id]: choice }));
+  }
+
+  if (!selectedProposal || !selectedTally) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-6" aria-labelledby="governance-heading">
+      <div>
+        <p className="text-sm font-medium uppercase text-axion-600 dark:text-axion-300">
+          Governance
+        </p>
+        <h1 id="governance-heading" className="mt-2 text-3xl font-bold text-slate-900 dark:text-white">
+          Proposals and voting
+        </h1>
+        <p className="mt-2 max-w-3xl text-slate-600 dark:text-slate-300">
+          Review active protocol proposals, inspect voting details, and cast a local dashboard vote.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <StatCard label="Active proposals" value={String(governanceSummary.active)} detail={`${proposals.length} total proposals`} />
+        <StatCard label="Recorded voting power" value={formatNumber(governanceSummary.totalVotes)} detail="Across visible proposals" />
+          <StatCard label="Quorum reached" value={String(governanceSummary.quorumReached)} detail="Across proposal tallies" />
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.4fr)]">
+        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-950/80">
+          <h2 className="px-2 text-lg font-semibold text-slate-900 dark:text-white">Proposal list</h2>
+          <div className="mt-4 space-y-3">
+            {proposals.map((proposal) => {
+              const tally = getProposalTally(proposal);
+              const isSelected = proposal.id === selectedProposal.id;
+
+              return (
+                <button
+                  key={proposal.id}
+                  type="button"
+                  onClick={() => setSelectedProposalId(proposal.id)}
+                  className={`w-full rounded-xl border p-4 text-left transition ${
+                    isSelected
+                      ? "border-axion-500 bg-axion-50 shadow-sm dark:bg-axion-950/30"
+                      : "border-slate-200 bg-slate-50 hover:border-axion-300 dark:border-slate-800 dark:bg-slate-900/60"
+                  }`}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <div className="text-xs font-medium uppercase text-slate-500 dark:text-slate-400">
+                        {proposal.id} · {proposal.category}
+                      </div>
+                      <div className="mt-1 font-semibold text-slate-900 dark:text-white">{proposal.title}</div>
+                    </div>
+                    <span className="shrink-0 rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200">
+                      {tally.stateLabel}
+                    </span>
+                  </div>
+                  <div className="mt-3 h-2 rounded-full bg-slate-200 dark:bg-slate-800">
+                    <div
+                      className="h-2 rounded-full bg-axion-500"
+                      style={{ width: formatGovernancePercent(tally.participationPercent) }}
+                      aria-hidden="true"
+                    />
+                  </div>
+                  <div className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                    {formatGovernancePercent(tally.participationPercent)} quorum participation
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <article className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-950/80">
+          <div className="flex flex-col gap-4 border-b border-slate-200 pb-5 dark:border-slate-800 md:flex-row md:items-start md:justify-between">
+            <div>
+              <div className="text-sm font-medium text-axion-600 dark:text-axion-300">{selectedProposal.id}</div>
+              <h2 className="mt-1 text-2xl font-semibold text-slate-900 dark:text-white">{selectedProposal.title}</h2>
+              <p className="mt-2 text-slate-600 dark:text-slate-300">{selectedProposal.summary}</p>
+            </div>
+            <span className="w-fit rounded-full bg-slate-100 px-3 py-1 text-sm font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200">
+              {selectedTally.stateLabel}
+            </span>
+          </div>
+
+          <div className="mt-5 grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <StatCard label="Support" value={formatGovernancePercent(selectedTally.supportPercent)} detail={`${formatNumber(selectedProposal.votesFor)} votes`} />
+            <StatCard label="Participation" value={formatGovernancePercent(selectedTally.participationPercent)} detail={`${formatNumber(selectedTally.totalVotes)} of ${formatNumber(selectedProposal.quorum)}`} />
+            <StatCard label="Voting ends" value={new Date(selectedProposal.votingEndsAt).toLocaleDateString()} detail={`Proposed by ${selectedProposal.proposer}`} />
+          </div>
+
+          <div className="mt-6 grid gap-3">
+            <div className="flex items-center justify-between text-sm">
+              <span className="font-medium text-slate-700 dark:text-slate-200">For</span>
+              <span className="text-slate-500 dark:text-slate-400">{formatNumber(selectedProposal.votesFor)}</span>
+            </div>
+            <div className="h-2 rounded-full bg-slate-200 dark:bg-slate-800">
+              <div className="h-2 rounded-full bg-emerald-500" style={{ width: formatGovernancePercent(selectedTally.supportPercent) }} />
+            </div>
+            <div className="grid grid-cols-2 gap-3 text-sm text-slate-500 dark:text-slate-400">
+              <div>Against: {formatNumber(selectedProposal.votesAgainst)}</div>
+              <div>Abstain: {formatNumber(selectedProposal.votesAbstain)}</div>
+            </div>
+          </div>
+
+          <div className="mt-6 rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900/70">
+            <h3 className="font-semibold text-slate-900 dark:text-white">Cast vote</h3>
+            <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+              {(Object.keys(voteLabels) as VoteChoice[]).map((choice) => (
+                <button
+                  key={choice}
+                  type="button"
+                  onClick={() => handleVote(choice)}
+                  className={`rounded-xl border px-4 py-3 text-sm font-semibold transition ${voteButtonClasses[choice]} ${
+                    selectedVote === choice ? "ring-2 ring-axion-400 ring-offset-2 dark:ring-offset-slate-950" : ""
+                  }`}
+                >
+                  {voteLabels[choice]}
+                </button>
+              ))}
+            </div>
+            <div className="mt-3 text-sm text-slate-600 dark:text-slate-300" aria-live="polite">
+              Your vote: {selectedVote ? voteLabels[selectedVote] : "Not voted"}
+            </div>
+          </div>
+
+          <div className="mt-6">
+            <h3 className="font-semibold text-slate-900 dark:text-white">Governance flow</h3>
+            <ol className="mt-3 grid gap-3 text-sm text-slate-600 dark:text-slate-300">
+              {selectedProposal.executionPlan.map((step, index) => (
+                <li key={step} className="flex gap-3 rounded-xl bg-slate-50 p-3 dark:bg-slate-900/70">
+                  <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-axion-100 text-xs font-semibold text-axion-700 dark:bg-axion-950 dark:text-axion-200">
+                    {index + 1}
+                  </span>
+                  <span>{step}</span>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </article>
+      </div>
+    </section>
+  );
+}

--- a/src/features/governance/governanceModel.ts
+++ b/src/features/governance/governanceModel.ts
@@ -1,0 +1,56 @@
+import type { GovernanceProposal, ProposalTally, VoteChoice } from "./types";
+
+const voteFieldByChoice: Record<VoteChoice, keyof Pick<GovernanceProposal, "votesFor" | "votesAgainst" | "votesAbstain">> = {
+  for: "votesFor",
+  against: "votesAgainst",
+  abstain: "votesAbstain"
+};
+
+export function getProposalTally(proposal: GovernanceProposal): ProposalTally {
+  const totalVotes = proposal.votesFor + proposal.votesAgainst + proposal.votesAbstain;
+  const participationPercent = proposal.quorum > 0 ? Math.min((totalVotes / proposal.quorum) * 100, 100) : 0;
+  const supportPercent = totalVotes > 0 ? (proposal.votesFor / totalVotes) * 100 : 0;
+  const quorumReached = totalVotes >= proposal.quorum;
+
+  let stateLabel = "Voting open";
+  if (proposal.state === "queued") {
+    stateLabel = "Queued";
+  } else if (proposal.state === "passed" || (proposal.state === "active" && quorumReached && proposal.votesFor > proposal.votesAgainst)) {
+    stateLabel = "Passing";
+  } else if (proposal.state === "rejected" || (proposal.state === "active" && quorumReached && proposal.votesAgainst >= proposal.votesFor)) {
+    stateLabel = "Not passing";
+  } else if (!quorumReached) {
+    stateLabel = "Quorum needed";
+  }
+
+  return {
+    totalVotes,
+    participationPercent,
+    supportPercent,
+    quorumReached,
+    stateLabel
+  };
+}
+
+export function castGovernanceVote(
+  proposal: GovernanceProposal,
+  nextVote: VoteChoice,
+  previousVote?: VoteChoice,
+  votingPower = 10000
+): GovernanceProposal {
+  const updated = { ...proposal };
+
+  if (previousVote) {
+    const previousField = voteFieldByChoice[previousVote];
+    updated[previousField] = Math.max(0, updated[previousField] - votingPower);
+  }
+
+  const nextField = voteFieldByChoice[nextVote];
+  updated[nextField] += votingPower;
+
+  return updated;
+}
+
+export function formatGovernancePercent(value: number): string {
+  return `${Math.round(value)}%`;
+}

--- a/src/features/governance/proposals.ts
+++ b/src/features/governance/proposals.ts
@@ -1,0 +1,65 @@
+import type { GovernanceProposal } from "./types";
+
+export const initialGovernanceProposals: GovernanceProposal[] = [
+  {
+    id: "avp-024",
+    title: "Launch community validator incentive round",
+    summary:
+      "Allocate a focused incentive budget for validators that improve uptime reporting, incident response, and testnet coverage.",
+    proposer: "Axionvera Core",
+    category: "Network Operations",
+    createdAt: "2026-06-18",
+    votingEndsAt: "2026-06-28",
+    quorum: 120000,
+    votesFor: 82300,
+    votesAgainst: 18100,
+    votesAbstain: 9600,
+    state: "active",
+    executionPlan: [
+      "Publish validator eligibility criteria",
+      "Open a two-week participation window",
+      "Review uptime and reporting evidence",
+      "Release final incentive allocation report"
+    ]
+  },
+  {
+    id: "avp-025",
+    title: "Prioritize vault analytics refresh cadence",
+    summary:
+      "Move vault analytics refreshes to a predictable schedule so dashboards show fresher balance, reward, and participation data.",
+    proposer: "Analytics Working Group",
+    category: "Dashboard",
+    createdAt: "2026-06-20",
+    votingEndsAt: "2026-06-30",
+    quorum: 95000,
+    votesFor: 54100,
+    votesAgainst: 12400,
+    votesAbstain: 8100,
+    state: "active",
+    executionPlan: [
+      "Document the refresh cadence",
+      "Add monitoring for stale analytics payloads",
+      "Surface last refresh time in the dashboard"
+    ]
+  },
+  {
+    id: "avp-023",
+    title: "Adopt treasury reporting template",
+    summary:
+      "Standardize monthly treasury reporting around inflows, outflows, protocol reserves, and open obligations.",
+    proposer: "Treasury Council",
+    category: "Treasury",
+    createdAt: "2026-06-10",
+    votingEndsAt: "2026-06-21",
+    quorum: 100000,
+    votesFor: 104500,
+    votesAgainst: 16800,
+    votesAbstain: 5700,
+    state: "passed",
+    executionPlan: [
+      "Publish template in governance docs",
+      "Backfill the previous monthly report",
+      "Use the template for the next reporting cycle"
+    ]
+  }
+];

--- a/src/features/governance/types.ts
+++ b/src/features/governance/types.ts
@@ -1,0 +1,27 @@
+export type VoteChoice = "for" | "against" | "abstain";
+
+export type ProposalState = "active" | "passed" | "rejected" | "queued";
+
+export type GovernanceProposal = {
+  id: string;
+  title: string;
+  summary: string;
+  proposer: string;
+  category: string;
+  createdAt: string;
+  votingEndsAt: string;
+  quorum: number;
+  votesFor: number;
+  votesAgainst: number;
+  votesAbstain: number;
+  state: ProposalState;
+  executionPlan: string[];
+};
+
+export type ProposalTally = {
+  totalVotes: number;
+  participationPercent: number;
+  supportPercent: number;
+  quorumReached: boolean;
+  stateLabel: string;
+};

--- a/src/pages/governance/index.tsx
+++ b/src/pages/governance/index.tsx
@@ -1,0 +1,41 @@
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+
+import Navbar from "@/components/Navbar";
+import Sidebar from "@/components/Sidebar";
+import GovernanceDashboard from "@/features/governance/GovernanceDashboard";
+import { useWalletContext } from "@/hooks/useWallet";
+
+export default function GovernancePage() {
+  const wallet = useWalletContext();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!wallet.isConnected && !wallet.isConnecting) {
+      router.replace("/");
+    }
+  }, [wallet.isConnected, wallet.isConnecting, router]);
+
+  return (
+    <>
+      <Head>
+        <title>Governance · Axionvera</title>
+      </Head>
+      <main className="min-h-screen bg-background-primary text-text-primary transition-colors duration-200">
+        <Sidebar />
+        <div className="flex-1 w-full transition-all lg:pl-64">
+          <Navbar
+            publicKey={wallet.publicKey}
+            isConnecting={wallet.isConnecting}
+            onConnect={wallet.connect}
+            onDisconnect={wallet.disconnect}
+          />
+          <div className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 md:py-8">
+            <GovernanceDashboard />
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/tests/components/GovernanceDashboard.test.tsx
+++ b/tests/components/GovernanceDashboard.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import GovernanceDashboard from "@/features/governance/GovernanceDashboard";
+
+describe("GovernanceDashboard", () => {
+  test("renders proposal list and selected proposal details", () => {
+    render(<GovernanceDashboard />);
+
+    expect(screen.getByRole("heading", { name: /proposals and voting/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /launch community validator incentive round/i })).toBeInTheDocument();
+    expect(screen.getByText(/Proposal list/i)).toBeInTheDocument();
+    expect(screen.getByText(/Governance flow/i)).toBeInTheDocument();
+  });
+
+  test("updates proposal state when a user casts and changes a vote", async () => {
+    const user = userEvent.setup();
+    render(<GovernanceDashboard />);
+
+    expect(screen.getByText(/Your vote: Not voted/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /^Support$/i }));
+    expect(screen.getByText(/Your vote: Support/i)).toBeInTheDocument();
+    expect(screen.getByText("92,300 votes")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /^Against$/i }));
+    expect(screen.getByText(/Your vote: Against/i)).toBeInTheDocument();
+    expect(screen.getByText("82,300 votes")).toBeInTheDocument();
+    expect(screen.getByText(/Against: 28,100/i)).toBeInTheDocument();
+  });
+
+  test("switches between proposal detail views", async () => {
+    const user = userEvent.setup();
+    render(<GovernanceDashboard />);
+
+    await user.click(screen.getByRole("button", { name: /prioritize vault analytics refresh cadence/i }));
+
+    expect(screen.getByRole("heading", { name: /prioritize vault analytics refresh cadence/i })).toBeInTheDocument();
+    expect(screen.getByText(/Analytics Working Group/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a governance dashboard for issue #220 so users can review proposals, inspect details, and cast support/against/abstain votes in the dashboard UI.

## Changes

- Added a protected `/governance` page using the existing wallet-protected app shell.
- Added governance proposal fixtures, types, vote tally helpers, and local vote-state updates.
- Added proposal listing, detail view, quorum/support summaries, voting controls, and governance flow steps.
- Added a Governance sidebar item.
- Added focused component tests for proposal rendering, detail switching, and vote updates.

## Testing/Verification

- `npm test -- tests/components/GovernanceDashboard.test.tsx --runInBand`
- `npm run lint`
- `Invoke-WebRequest http://127.0.0.1:3020/governance` confirmed the server-rendered route contains the governance page content.

Known existing repo gaps:

- `npm run typecheck` currently fails in unchanged existing files because `src/components/BalanceTrendChart.tsx` imports missing `recharts` types/dependency and `tests/hooks/useVault.test.ts` has a stale mock type.
- Full `npm test -- --runInBand` currently fails in unchanged existing deposit/withdraw tests that submit while disconnected.
- `npm run build` reaches Next type checking and then fails on the unchanged missing `recharts` import.

## Governance Flow

```text
Proposal list -> Proposal detail -> Cast support/against/abstain vote -> Local tally/quorum state updates
```

Closes #220
