### PR TITLE
feat: add protocol monitoring dashboard

### DIFF
--- a/src/charts/HealthLatencyBars.tsx
+++ b/src/charts/HealthLatencyBars.tsx
@@ -1,0 +1,40 @@
+import type { ProtocolHealthStatus } from "@/services/protocolHealth";
+
+type HealthLatencyBarsProps = {
+  data: Array<{ label: string; latencyMs: number; status: ProtocolHealthStatus }>;
+};
+
+const STATUS_CLASS: Record<ProtocolHealthStatus, string> = {
+  operational: "bg-emerald-500",
+  degraded: "bg-amber-500",
+  down: "bg-red-500",
+};
+
+export default function HealthLatencyBars({ data }: HealthLatencyBarsProps) {
+  const maxLatency = Math.max(...data.map((item) => item.latencyMs), 1);
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-950/80">
+      <div className="mb-5">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Endpoint Latency</h2>
+        <p className="text-sm text-slate-500 dark:text-slate-400">Latest frontend probe response time.</p>
+      </div>
+      <div className="space-y-4">
+        {data.map((item) => {
+          const width = `${Math.max(8, Math.round((item.latencyMs / maxLatency) * 100))}%`;
+          return (
+            <div key={item.label}>
+              <div className="mb-1 flex items-center justify-between text-sm">
+                <span className="font-medium text-slate-700 dark:text-slate-200">{item.label}</span>
+                <span className="tabular-nums text-slate-500 dark:text-slate-400">{item.latencyMs} ms</span>
+              </div>
+              <div className="h-3 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800">
+                <div className={`h-full rounded-full ${STATUS_CLASS[item.status]}`} style={{ width }} />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -73,6 +73,15 @@ export default function Sidebar({ className = "" }: SidebarProps) {
       ),
     },
     {
+      href: "/monitoring",
+      label: "Monitoring",
+      icon: (
+        <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
+        </svg>
+      ),
+    },
+    {
       href: "https://stellar.org/soroban",
       label: "Soroban",
       icon: (

--- a/src/features/monitoring/ProtocolHealthDashboard.tsx
+++ b/src/features/monitoring/ProtocolHealthDashboard.tsx
@@ -1,0 +1,125 @@
+import HealthLatencyBars from "@/charts/HealthLatencyBars";
+import { useProtocolHealth } from "@/hooks/useProtocolHealth";
+import type { ProtocolHealthStatus } from "@/services/protocolHealth";
+
+const STATUS_COPY: Record<ProtocolHealthStatus, { label: string; className: string; dot: string }> = {
+  operational: {
+    label: "Operational",
+    className: "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-300",
+    dot: "bg-emerald-500",
+  },
+  degraded: {
+    label: "Degraded",
+    className: "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-300",
+    dot: "bg-amber-500",
+  },
+  down: {
+    label: "Down",
+    className: "border-red-200 bg-red-50 text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300",
+    dot: "bg-red-500",
+  },
+};
+
+function formatCheckedAt(value: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(new Date(value));
+}
+
+export default function ProtocolHealthDashboard() {
+  const { snapshot, isLoading, error, refresh } = useProtocolHealth();
+  const status = snapshot?.status ?? "degraded";
+  const statusCopy = STATUS_COPY[status];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-slate-900 dark:text-white">Protocol Monitoring</h1>
+          <p className="mt-2 max-w-2xl text-slate-600 dark:text-slate-300">
+            Live protocol health metrics for the dashboard&apos;s Stellar, Soroban, contract, and transaction dependencies.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void refresh()}
+          className="inline-flex items-center justify-center rounded-xl bg-axion-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-axion-700 disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={isLoading}
+        >
+          {isLoading ? "Refreshing..." : "Refresh Status"}
+        </button>
+      </div>
+
+      <section className={`rounded-2xl border p-6 ${statusCopy.className}`}>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <div className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide">
+              <span className={`h-2.5 w-2.5 rounded-full ${statusCopy.dot}`} />
+              {statusCopy.label}
+            </div>
+            <p className="mt-2 text-lg font-semibold">{snapshot?.summary ?? "Loading protocol health metrics."}</p>
+          </div>
+          {snapshot ? (
+            <div className="text-sm">
+              Last checked <span className="font-semibold">{formatCheckedAt(snapshot.checkedAt)}</span>
+            </div>
+          ) : null}
+        </div>
+      </section>
+
+      {error ? (
+        <div className="rounded-2xl border border-red-200 bg-red-50 p-5 text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="grid gap-4 lg:col-span-2 md:grid-cols-2">
+          {(snapshot?.metrics ?? []).map((metric) => {
+            const metricStatus = STATUS_COPY[metric.status];
+            return (
+              <article
+                key={metric.id}
+                className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-950/80"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <h2 className="font-semibold text-slate-900 dark:text-white">{metric.label}</h2>
+                    <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{metric.description}</p>
+                  </div>
+                  <span className={`rounded-full border px-2.5 py-1 text-xs font-medium ${metricStatus.className}`}>
+                    {metricStatus.label}
+                  </span>
+                </div>
+                <div className="mt-5 text-xl font-semibold text-slate-900 dark:text-white">{metric.value}</div>
+                <div className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+                  {metric.latencyMs ? `${metric.latencyMs} ms latency` : `Checked ${formatCheckedAt(metric.checkedAt)}`}
+                </div>
+              </article>
+            );
+          })}
+
+          {isLoading && !snapshot ? (
+            <>
+              {[0, 1, 2, 3].map((item) => (
+                <div key={item} className="h-40 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/60" />
+              ))}
+            </>
+          ) : null}
+        </div>
+
+        <div className="space-y-6">
+          {snapshot ? <HealthLatencyBars data={snapshot.latencyTrend} /> : null}
+          <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-950/80">
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Polling</h2>
+            <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+              Health status refreshes automatically every {Math.round((snapshot?.nextCheckInMs ?? 30000) / 1000)} seconds.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useProtocolHealth.ts
+++ b/src/hooks/useProtocolHealth.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  DEFAULT_PROTOCOL_HEALTH_POLL_MS,
+  getProtocolHealthSnapshot,
+  type ProtocolHealthSnapshot,
+} from "@/services/protocolHealth";
+
+type ProtocolHealthState = {
+  snapshot: ProtocolHealthSnapshot | null;
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+};
+
+export function useProtocolHealth(pollIntervalMs = DEFAULT_PROTOCOL_HEALTH_POLL_MS): ProtocolHealthState {
+  const [snapshot, setSnapshot] = useState<ProtocolHealthSnapshot | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const isMounted = useRef(false);
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const nextSnapshot = await getProtocolHealthSnapshot();
+      if (isMounted.current) {
+        setSnapshot(nextSnapshot);
+      }
+    } catch (err) {
+      if (isMounted.current) {
+        setError(err instanceof Error ? err.message : "Failed to load protocol health.");
+      }
+    } finally {
+      if (isMounted.current) {
+        setIsLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    isMounted.current = true;
+    void refresh();
+
+    const interval = window.setInterval(() => {
+      void refresh();
+    }, pollIntervalMs);
+
+    return () => {
+      isMounted.current = false;
+      window.clearInterval(interval);
+    };
+  }, [pollIntervalMs, refresh]);
+
+  return { snapshot, isLoading, error, refresh };
+}

--- a/src/pages/monitoring.tsx
+++ b/src/pages/monitoring.tsx
@@ -1,0 +1,41 @@
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+
+import Navbar from "@/components/Navbar";
+import Sidebar from "@/components/Sidebar";
+import ProtocolHealthDashboard from "@/features/monitoring/ProtocolHealthDashboard";
+import { useWalletContext } from "@/hooks/useWallet";
+
+export default function MonitoringPage() {
+  const wallet = useWalletContext();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!wallet.isConnected && !wallet.isConnecting) {
+      router.replace("/");
+    }
+  }, [wallet.isConnected, wallet.isConnecting, router]);
+
+  return (
+    <>
+      <Head>
+        <title>Protocol Monitoring · Axionvera</title>
+      </Head>
+      <main className="min-h-screen bg-background-primary text-text-primary transition-colors duration-200">
+        <Sidebar />
+        <div className="flex-1 w-full transition-all lg:pl-64">
+          <Navbar
+            publicKey={wallet.publicKey}
+            isConnecting={wallet.isConnecting}
+            onConnect={wallet.connect}
+            onDisconnect={wallet.disconnect}
+          />
+          <div className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 md:py-8">
+            <ProtocolHealthDashboard />
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/services/protocolHealth.ts
+++ b/src/services/protocolHealth.ts
@@ -1,0 +1,175 @@
+import {
+  AXIONVERA_TOKEN_CONTRACT_ID,
+  AXIONVERA_VAULT_CONTRACT_ID,
+  HORIZON_URL,
+  NETWORK,
+  SOROBAN_RPC_URL,
+} from "@/utils/networkConfig";
+
+export type ProtocolHealthStatus = "operational" | "degraded" | "down";
+
+export type ProtocolHealthMetric = {
+  id: string;
+  label: string;
+  description: string;
+  value: string;
+  status: ProtocolHealthStatus;
+  latencyMs?: number;
+  checkedAt: string;
+};
+
+export type ProtocolHealthSnapshot = {
+  status: ProtocolHealthStatus;
+  summary: string;
+  checkedAt: string;
+  nextCheckInMs: number;
+  metrics: ProtocolHealthMetric[];
+  latencyTrend: Array<{ label: string; latencyMs: number; status: ProtocolHealthStatus }>;
+};
+
+type ProbeResult = {
+  ok: boolean;
+  latencyMs?: number;
+  message: string;
+};
+
+const DEFAULT_TIMEOUT_MS = 4500;
+export const DEFAULT_PROTOCOL_HEALTH_POLL_MS = 30000;
+
+function isConfigured(value: string) {
+  return Boolean(value && !value.startsWith("REPLACE_WITH_"));
+}
+
+function metricStatus(ok: boolean, latencyMs?: number): ProtocolHealthStatus {
+  if (!ok) return "down";
+  if (latencyMs && latencyMs > 2500) return "degraded";
+  return "operational";
+}
+
+function summarizeStatus(statuses: ProtocolHealthStatus[]): ProtocolHealthStatus {
+  if (statuses.some((status) => status === "down")) return "down";
+  if (statuses.some((status) => status === "degraded")) return "degraded";
+  return "operational";
+}
+
+async function probeEndpoint(
+  url: string,
+  options: RequestInit,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<ProbeResult> {
+  const startedAt = performance.now();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      ...options,
+      signal: controller.signal,
+    });
+    const latencyMs = Math.round(performance.now() - startedAt);
+
+    return {
+      ok: response.ok,
+      latencyMs,
+      message: response.ok ? `${response.status} OK` : `${response.status} ${response.statusText}`,
+    };
+  } catch (error) {
+    const latencyMs = Math.round(performance.now() - startedAt);
+    return {
+      ok: false,
+      latencyMs,
+      message: error instanceof Error ? error.message : "Endpoint probe failed",
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function getProtocolHealthSnapshot(): Promise<ProtocolHealthSnapshot> {
+  const checkedAt = new Date().toISOString();
+
+  const [rpcProbe, horizonProbe] = await Promise.all([
+    probeEndpoint(SOROBAN_RPC_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "protocol-health",
+        method: "getHealth",
+      }),
+    }),
+    probeEndpoint(`${HORIZON_URL.replace(/\/$/, "")}/`, { method: "GET" }),
+  ]);
+
+  const contractConfigured = isConfigured(AXIONVERA_VAULT_CONTRACT_ID) && isConfigured(AXIONVERA_TOKEN_CONTRACT_ID);
+  const rpcStatus = metricStatus(rpcProbe.ok, rpcProbe.latencyMs);
+  const horizonStatus = metricStatus(horizonProbe.ok, horizonProbe.latencyMs);
+  const contractStatus: ProtocolHealthStatus = contractConfigured ? "operational" : "degraded";
+  const eventStatus: ProtocolHealthStatus = rpcStatus === "operational" ? "operational" : "degraded";
+  const transactionStatus: ProtocolHealthStatus =
+    rpcStatus === "operational" && horizonStatus !== "down" && contractConfigured ? "operational" : "degraded";
+
+  const metrics: ProtocolHealthMetric[] = [
+    {
+      id: "soroban-rpc",
+      label: "Soroban RPC",
+      description: "Protocol write/read path for contract simulation and submission.",
+      value: rpcProbe.message,
+      status: rpcStatus,
+      latencyMs: rpcProbe.latencyMs,
+      checkedAt,
+    },
+    {
+      id: "horizon",
+      label: "Horizon Indexer",
+      description: "Stellar account and ledger indexing endpoint used by the dashboard.",
+      value: horizonProbe.message,
+      status: horizonStatus,
+      latencyMs: horizonProbe.latencyMs,
+      checkedAt,
+    },
+    {
+      id: "contract-config",
+      label: "Contract Configuration",
+      description: `Vault and token contract IDs for ${NETWORK}.`,
+      value: contractConfigured ? "Vault and token contracts configured" : "Contract IDs need environment configuration",
+      status: contractStatus,
+      checkedAt,
+    },
+    {
+      id: "event-stream",
+      label: "Event Stream",
+      description: "Soroban event stream readiness for automatic dashboard refreshes.",
+      value: rpcStatus === "operational" ? "Ready for event-backed refresh" : "Waiting on healthy RPC",
+      status: eventStatus,
+      checkedAt,
+    },
+    {
+      id: "transaction-flow",
+      label: "Transaction Flow",
+      description: "Combined readiness for deposits, withdrawals, and reward claims.",
+      value: transactionStatus === "operational" ? "Ready" : "Limited until dependencies recover",
+      status: transactionStatus,
+      checkedAt,
+    },
+  ];
+
+  const status = summarizeStatus(metrics.map((metric) => metric.status));
+
+  return {
+    status,
+    summary:
+      status === "operational"
+        ? "All monitored protocol dependencies are healthy."
+        : status === "degraded"
+          ? "One or more protocol dependencies need attention."
+          : "A critical protocol dependency is unavailable.",
+    checkedAt,
+    nextCheckInMs: DEFAULT_PROTOCOL_HEALTH_POLL_MS,
+    metrics,
+    latencyTrend: [
+      { label: "RPC", latencyMs: rpcProbe.latencyMs ?? 0, status: rpcStatus },
+      { label: "Horizon", latencyMs: horizonProbe.latencyMs ?? 0, status: horizonStatus },
+    ],
+  };
+}

--- a/tests/components/ProtocolHealthDashboard.test.tsx
+++ b/tests/components/ProtocolHealthDashboard.test.tsx
@@ -1,0 +1,80 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+
+import ProtocolHealthDashboard from "@/features/monitoring/ProtocolHealthDashboard";
+import { getProtocolHealthSnapshot, type ProtocolHealthSnapshot } from "@/services/protocolHealth";
+
+jest.mock("@/services/protocolHealth", () => ({
+  DEFAULT_PROTOCOL_HEALTH_POLL_MS: 30000,
+  getProtocolHealthSnapshot: jest.fn(),
+}));
+
+const mockedGetSnapshot = getProtocolHealthSnapshot as jest.MockedFunction<typeof getProtocolHealthSnapshot>;
+
+function createSnapshot(status: ProtocolHealthSnapshot["status"], checkedAt: string): ProtocolHealthSnapshot {
+  return {
+    status,
+    checkedAt,
+    nextCheckInMs: 30000,
+    summary: status === "operational" ? "All monitored protocol dependencies are healthy." : "One or more protocol dependencies need attention.",
+    metrics: [
+      {
+        id: "soroban-rpc",
+        label: "Soroban RPC",
+        description: "Protocol write/read path.",
+        value: "200 OK",
+        status,
+        latencyMs: 125,
+        checkedAt,
+      },
+      {
+        id: "contract-config",
+        label: "Contract Configuration",
+        description: "Vault and token contract IDs.",
+        value: "Vault and token contracts configured",
+        status: "operational",
+        checkedAt,
+      },
+    ],
+    latencyTrend: [{ label: "RPC", latencyMs: 125, status }],
+  };
+}
+
+describe("ProtocolHealthDashboard", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockedGetSnapshot.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("renders protocol health metrics", async () => {
+    mockedGetSnapshot.mockResolvedValue(createSnapshot("operational", "2026-06-23T20:00:00.000Z"));
+
+    render(<ProtocolHealthDashboard />);
+
+    expect(await screen.findByRole("heading", { name: /protocol monitoring/i })).toBeInTheDocument();
+    expect(await screen.findByText(/all monitored protocol dependencies are healthy/i)).toBeInTheDocument();
+    expect(screen.getByText("Soroban RPC")).toBeInTheDocument();
+    expect(screen.getByText("Contract Configuration")).toBeInTheDocument();
+    expect(screen.getByText(/125 ms latency/i)).toBeInTheDocument();
+  });
+
+  test("polls automatically for updated health status", async () => {
+    mockedGetSnapshot
+      .mockResolvedValueOnce(createSnapshot("operational", "2026-06-23T20:00:00.000Z"))
+      .mockResolvedValueOnce(createSnapshot("degraded", "2026-06-23T20:00:30.000Z"));
+
+    render(<ProtocolHealthDashboard />);
+
+    expect(await screen.findByText(/all monitored protocol dependencies are healthy/i)).toBeInTheDocument();
+
+    await act(async () => {
+      jest.advanceTimersByTime(30000);
+    });
+
+    await waitFor(() => expect(mockedGetSnapshot).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText(/one or more protocol dependencies need attention/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a frontend protocol monitoring dashboard for issue #221 so operators can review protocol health metrics, dependency status, and automatic polling state from the dashboard UI.

## Changes

- Added a protected `/monitoring` page using the existing dashboard shell.
- Added protocol health snapshot service checks for Soroban RPC, Horizon, contract configuration, event stream readiness, and transaction flow readiness.
- Added a polling hook that refreshes monitoring status automatically every 30 seconds and supports manual refresh.
- Added monitoring metric cards and endpoint latency bars.
- Added a Monitoring sidebar navigation item.
- Added focused component tests for metric rendering and automatic polling refresh.

## Testing/Verification

- `git diff --check`
- `npm test -- tests/components/ProtocolHealthDashboard.test.tsx --runInBand`
- `npm run lint`
- `Invoke-WebRequest http://127.0.0.1:3021/monitoring` confirmed the server-rendered route contains the monitoring page content and sidebar link.

Known existing repo gaps:

- `npm run lint` passes with an existing warning in `src/components/BalanceCard.tsx`.
- `npm run typecheck` currently fails in unchanged existing files because `src/components/BalanceTrendChart.tsx` imports missing `recharts` and `tests/hooks/useVault.test.ts` has a stale mock missing `getAnalytics`.
- Full `npm test -- --runInBand` currently fails in unchanged existing `DepositForm` and `WithdrawForm` tests that submit while disconnected.
- `npm run build` is blocked in this isolated clone by missing production environment variables before compilation starts.
- Playwright screenshot smoke could not run because the local Playwright Chromium binary is not installed; I did not download a new browser/toolchain for this PR.

## Metrics Shown

- Soroban RPC health and latency
- Horizon indexer health and latency
- Vault/token contract configuration status
- Soroban event stream readiness
- Deposit/withdraw/reward transaction flow readiness

Closes #221
