### PR TITLE
feat: multi-wallet provider registry with Freighter and Albedo support

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,10 +17,14 @@ Axionvera Dashboard is a Next.js (Pages Router) application with a small set of 
 ## Key Modules
 
 - `src/pages/dashboard.tsx`: wires wallet + vault hooks into the main dashboard UI
-- `src/hooks/useWallet.ts`: Stellar wallet integration (Freighter API)
+- `src/hooks/useWallet.ts`: re-exports from WalletContext (see wallet-architecture.md for the full stack)
+- `src/wallets/`: wallet provider interface, registry, and built-in adapters (Freighter, Albedo)
+- `src/services/walletService.ts`: thin service layer — connect/disconnect/switch/restoreSession
 - `src/hooks/useVault.ts`: vault orchestration (load state, submit actions, refresh)
 - `src/utils/networkConfig.ts`: Soroban RPC + Horizon configuration and contract IDs
 - `src/utils/contractHelpers.ts`: SDK adapter interface + default mock implementation
+
+See [wallet-architecture.md](./wallet-architecture.md) for a complete guide to the multi-wallet provider registry.
 
 ## SDK and Contract Interaction
 

--- a/docs/wallet-architecture.md
+++ b/docs/wallet-architecture.md
@@ -1,0 +1,208 @@
+# Wallet Architecture
+
+## Overview
+
+Axionvera Dashboard supports multiple Stellar wallet providers through a
+**provider registry** pattern.  Each wallet is an isolated adapter module;
+the UI discovers and switches wallets at runtime without any changes to page
+components or the wallet context.
+
+---
+
+## Directory Structure
+
+```
+src/
+├── wallets/
+│   ├── types.ts              # WalletProvider interface, WalletMeta, WalletId, WalletAdapterError
+│   ├── registry.ts           # WalletRegistry singleton
+│   ├── index.ts              # Barrel export + bootstraps built-in adapters
+│   └── adapters/
+│       ├── freighter.ts      # Freighter browser-extension adapter
+│       └── albedo.ts         # Albedo web-intent adapter
+├── services/
+│   └── walletService.ts      # connect / disconnect / switchWallet / restoreSession
+├── contexts/
+│   └── WalletContext.tsx     # React context — delegates to walletService
+├── hooks/
+│   └── useWallet.ts          # Re-exports from WalletContext
+└── types/
+    └── wallet.ts             # Public re-export of wallet types
+```
+
+---
+
+## How the Registry Works
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  src/wallets/index.ts  (bootstraps on import)                   │
+│                                                                 │
+│  walletRegistry.register("freighter", createFreighterAdapter)   │
+│  walletRegistry.register("albedo",    createAlbedoAdapter)      │
+└────────────────────────────────┬────────────────────────────────┘
+                                 │
+                                 ▼
+               ┌─────────────────────────────┐
+               │     WalletRegistry          │
+               │  Map<WalletId, Factory>     │
+               │                             │
+               │  list()         → WalletMeta[]   (UI picker)
+               │  createAdapter()→ WalletProvider  (lazy init)
+               └─────────────────┬───────────┘
+                                 │
+                                 ▼
+               ┌─────────────────────────────┐
+               │     walletService.ts        │
+               │                             │
+               │  connectWallet(id)          │
+               │  disconnectWallet(id)       │
+               │  switchWallet(curr, new)    │
+               │  restoreSession()           │
+               │  getAvailableWallets()      │
+               └─────────────────┬───────────┘
+                                 │
+                                 ▼
+               ┌─────────────────────────────┐
+               │     WalletContext.tsx       │
+               │  React state + effects      │
+               │  Exposes: connect,          │
+               │  disconnect, switchWallet,  │
+               │  availableWallets           │
+               └─────────────────────────────┘
+```
+
+### Key design decisions
+
+| Decision | Rationale |
+|---|---|
+| Factories stored, not instances | Adapters are instantiated lazily to avoid extension pings at import time |
+| Service layer (no React) | `walletService.ts` contains only plain async functions — easy to unit-test without a browser |
+| Session restore on mount | `restoreSession()` iterates registered adapters in order; first active session wins |
+| Registry is a module-level singleton | One registry per page — safe in SSR because adapters guard `typeof window` |
+
+---
+
+## Built-in Wallets
+
+| ID | Label | Extension required? | Capabilities |
+|---|---|---|---|
+| `freighter` | Freighter | Yes (browser extension) | publicKey, signTransaction |
+| `albedo` | Albedo | No (web-based popup) | publicKey |
+
+---
+
+## Adding a New Wallet Adapter
+
+Follow these four steps — **no other files need to change**.
+
+### 1. Extend `WalletId`
+
+```ts
+// src/wallets/types.ts
+export type WalletId = "freighter" | "albedo" | "rabet";   // ← add your id
+```
+
+### 2. Create the adapter
+
+```ts
+// src/wallets/adapters/rabet.ts
+import { WalletProvider, WalletMeta, WalletAdapterError } from "../types";
+import { StellarNetwork } from "@/utils/networkConfig";
+
+const RABET_META: WalletMeta = {
+  id: "rabet",
+  label: "Rabet",
+  description: "Stellar browser extension wallet.",
+  installUrl: "https://rabet.io",
+  icon: `<svg>…</svg>`,
+  capabilities: { publicKey: true, signTransaction: true, signAuthEntry: false },
+};
+
+export class RabetAdapter implements WalletProvider {
+  readonly meta = RABET_META;
+
+  async isAvailable() { /* check window.rabet */ }
+  async isConnected()  { /* check permission */ }
+  async connect()      { /* return { address, network } */ }
+  async disconnect()   { /* cleanup */ }
+  async getActiveSession() { /* poll for changes */ }
+}
+
+export function createRabetAdapter() { return new RabetAdapter(); }
+```
+
+### 3. Register in `src/wallets/index.ts`
+
+```ts
+import { createRabetAdapter } from "./adapters/rabet";
+walletRegistry.register("rabet", createRabetAdapter);
+```
+
+### 4. Document here
+
+Add a row to the **Built-in Wallets** table above.
+
+---
+
+## Capability Flags
+
+```ts
+interface WalletCapabilities {
+  publicKey: boolean;       // can return the user's Stellar public key
+  signTransaction: boolean; // can sign and submit Stellar XDR transactions
+  signAuthEntry: boolean;   // can sign Soroban auth entries (contract interactions)
+}
+```
+
+The UI uses these flags to show or grey out advanced actions.  Future features
+(e.g. Soroban contract auth) will check `capabilities.signAuthEntry` before
+offering the action.
+
+---
+
+## Migration from the Old `WalletType` String Union
+
+The original `WalletContext` used:
+
+```ts
+type WalletType = "freighter" | "albedo";
+connect: (walletType: WalletType) => Promise<void>;
+```
+
+This is unchanged at the call site — `WalletId` is a drop-in alias:
+
+```ts
+// Before
+connect("freighter");
+
+// After (identical call, new type backing it)
+connect("freighter");
+```
+
+The new additions on the context are additive:
+
+```ts
+availableWallets: WalletMeta[]        // read the list of registered wallets
+switchWallet(newId: WalletId): Promise<void>  // atomic disconnect → connect
+```
+
+---
+
+## Testing
+
+- **Adapter unit tests** — instantiate the adapter directly and mock the
+  underlying library (`@stellar/freighter-api`, `@albedo-link/intent`).
+- **Registry tests** — use `walletRegistry._reset()` to start with an empty
+  registry per test, then register a mock adapter.
+- **Service tests** — import `walletService` functions directly (no React).
+- **Context tests** — use `@testing-library/react` with a mock registry.
+
+---
+
+## Out of Scope
+
+Hardware wallet support (Ledger, Trezor) is **explicitly out of scope** for
+this feature.  The `WalletProvider` interface is designed to accommodate a
+hardware adapter in a future PR — implement `signTransaction` using the
+`@ledgerhq/stellar` transport when ready.

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -4,27 +4,81 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 import { useSidebar } from "@/hooks/useSidebar";
 import { shortenAddress } from "@/utils/contractHelpers";
-import CopyButton from "./CopyButton";
 import ThemeToggle from "./ThemeToggle";
+import { WalletId, WalletMeta } from "@/types/wallet";
 
 type NavbarProps = {
   publicKey: string | null;
   isConnecting: boolean;
-  onConnect: (walletType: any) => Promise<void>;
+  walletType: WalletId | null;
+  availableWallets: WalletMeta[];
+  onConnect: (walletType: WalletId) => Promise<void>;
   onDisconnect: () => void;
+  onSwitch: (walletType: WalletId) => Promise<void>;
 };
 
-export default function Navbar({ publicKey, isConnecting, onConnect, onDisconnect }: NavbarProps) {
+/** Inline SVG icon renderer — wallets ship their own SVG strings. */
+function WalletIcon({ svg, label }: { svg: string; label: string }) {
+  return (
+    <span
+      className="h-5 w-5 shrink-0 [&>svg]:h-full [&>svg]:w-full"
+      aria-hidden="true"
+      dangerouslySetInnerHTML={{ __html: svg }}
+      title={label}
+    />
+  );
+}
+
+export default function Navbar({
+  publicKey,
+  isConnecting,
+  walletType,
+  availableWallets,
+  onConnect,
+  onDisconnect,
+  onSwitch,
+}: NavbarProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isWalletDropdownOpen, setIsWalletDropdownOpen] = useState(false);
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [walletAvailability, setWalletAvailability] = useState<Record<string, boolean>>({});
   const walletDropdownRef = useRef<HTMLDivElement>(null);
+  const walletPickerRef = useRef<HTMLDivElement>(null);
   const { isOpen: isSidebarOpen, toggle: toggleSidebar } = useSidebar();
+
   const short = useMemo(
     () => (publicKey ? shortenAddress(publicKey, 6) : null),
-    [publicKey]
+    [publicKey],
   );
 
-  // Close the wallet dropdown when clicking outside of it
+  const activeWalletMeta = useMemo(
+    () => availableWallets.find((w) => w.id === walletType) ?? null,
+    [availableWallets, walletType],
+  );
+
+  /** Pre-check availability for every wallet so the picker can show "Install" links. */
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    let cancelled = false;
+    (async () => {
+      const entries = await Promise.all(
+        availableWallets.map(async (w) => {
+          try {
+            // Dynamic import to avoid bundling isWalletAvailable at top-level
+            const { isWalletAvailable } = await import("@/services/walletService");
+            const ok = await isWalletAvailable(w.id);
+            return [w.id, ok] as const;
+          } catch {
+            return [w.id, false] as const;
+          }
+        }),
+      );
+      if (!cancelled) setWalletAvailability(Object.fromEntries(entries));
+    })();
+    return () => { cancelled = true; };
+  }, [availableWallets]);
+
+  // Close connected-wallet dropdown on outside click
   useEffect(() => {
     if (!isWalletDropdownOpen) return;
     function handleClickOutside(e: MouseEvent) {
@@ -32,9 +86,21 @@ export default function Navbar({ publicKey, isConnecting, onConnect, onDisconnec
         setIsWalletDropdownOpen(false);
       }
     }
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [isWalletDropdownOpen]);
+
+  // Close wallet picker on outside click
+  useEffect(() => {
+    if (!isPickerOpen) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (walletPickerRef.current && !walletPickerRef.current.contains(e.target as Node)) {
+        setIsPickerOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isPickerOpen]);
 
   return (
     <header className="sticky top-0 z-20 border-b border-slate-200 dark:border-slate-800 bg-white/80 dark:bg-slate-950/80 backdrop-blur transition-colors duration-300">
@@ -81,7 +147,7 @@ export default function Navbar({ publicKey, isConnecting, onConnect, onDisconnec
               stroke="currentColor"
               strokeWidth="2"
               aria-hidden="true"
-              style={{ transform: isSidebarOpen ? 'rotate(180deg)' : 'rotate(0deg)' }}
+              style={{ transform: isSidebarOpen ? "rotate(180deg)" : "rotate(0deg)" }}
             >
               <path strokeLinecap="round" strokeLinejoin="round" d="M13 5l7 7-7 7M5 5l7 7-7 7" />
             </svg>
@@ -125,6 +191,8 @@ export default function Navbar({ publicKey, isConnecting, onConnect, onDisconnec
 
         <div className="flex items-center gap-4">
           <ThemeToggle />
+
+          {/* ── Connected state ─────────────────────────────────────────── */}
           {publicKey ? (
             <div className="relative" ref={walletDropdownRef}>
               {/* Wallet address badge — click to open dropdown */}
@@ -137,35 +205,45 @@ export default function Navbar({ publicKey, isConnecting, onConnect, onDisconnec
                 aria-expanded={isWalletDropdownOpen}
                 className="flex items-center gap-2 rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-100/30 dark:bg-slate-900/30 px-3 py-2 text-xs text-slate-700 dark:text-slate-200 transition hover:bg-slate-200/50 dark:hover:bg-slate-900/60"
               >
+                {activeWalletMeta && (
+                  <WalletIcon svg={activeWalletMeta.icon} label={activeWalletMeta.label} />
+                )}
                 <span className="h-2 w-2 rounded-full bg-green-500" aria-hidden="true" />
                 <span className="hidden sm:inline">{short}</span>
                 <svg
-                  className={`h-3 w-3 transition-transform duration-200 ${isWalletDropdownOpen ? 'rotate-180' : ''}`}
+                  className={`h-3 w-3 transition-transform duration-200 ${isWalletDropdownOpen ? "rotate-180" : ""}`}
                   fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2.5" aria-hidden="true"
                 >
                   <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
                 </svg>
               </button>
 
-              {/* Dropdown panel */}
+              {/* Connected wallet dropdown */}
               {isWalletDropdownOpen && (
                 <div
                   role="menu"
                   aria-labelledby="wallet-menu-button"
-                  className="absolute right-0 mt-2 w-64 origin-top-right rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 shadow-xl ring-1 ring-black/5 dark:ring-white/5 z-50"
+                  className="absolute right-0 mt-2 w-72 origin-top-right rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 shadow-xl ring-1 ring-black/5 dark:ring-white/5 z-50"
                 >
                   {/* Address display */}
                   <div className="px-4 pt-3 pb-2">
-                    <p className="text-xs text-slate-500 dark:text-slate-400">Connected wallet</p>
+                    <div className="flex items-center gap-2 mb-1">
+                      {activeWalletMeta && (
+                        <WalletIcon svg={activeWalletMeta.icon} label={activeWalletMeta.label} />
+                      )}
+                      <p className="text-xs font-medium text-slate-700 dark:text-slate-200">
+                        {activeWalletMeta?.label ?? "Connected wallet"}
+                      </p>
+                    </div>
                     <p
-                      className="mt-1 break-all font-mono text-xs text-slate-800 dark:text-slate-100 select-all"
-                      title={publicKey ?? ''}
+                      className="break-all font-mono text-xs text-slate-500 dark:text-slate-400 select-all"
+                      title={publicKey ?? ""}
                     >
                       {publicKey}
                     </p>
                   </div>
 
-                  <div className="border-t border-slate-100 dark:border-slate-800 px-2 py-2">
+                  <div className="border-t border-slate-100 dark:border-slate-800 px-2 py-2 space-y-0.5">
                     {/* Copy address */}
                     <button
                       id="navbar-copy-address"
@@ -182,6 +260,24 @@ export default function Navbar({ publicKey, isConnecting, onConnect, onDisconnec
                       </svg>
                       Copy Address
                     </button>
+
+                    {/* Switch wallet — lists other available wallets */}
+                    {availableWallets.filter((w) => w.id !== walletType).map((w) => (
+                      <button
+                        key={w.id}
+                        id={`navbar-switch-wallet-${w.id}`}
+                        type="button"
+                        role="menuitem"
+                        onClick={async () => {
+                          setIsWalletDropdownOpen(false);
+                          await onSwitch(w.id);
+                        }}
+                        className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-900/60 transition"
+                      >
+                        <WalletIcon svg={w.icon} label={w.label} />
+                        Switch to {w.label}
+                      </button>
+                    ))}
 
                     {/* Disconnect */}
                     <button
@@ -204,16 +300,81 @@ export default function Navbar({ publicKey, isConnecting, onConnect, onDisconnec
                 </div>
               )}
             </div>
+
           ) : (
-            <button
-              type="button"
-              onClick={() => onConnect('freighter')}
-              disabled={isConnecting}
-              aria-label={isConnecting ? "Connecting to Stellar wallet" : "Connect Stellar wallet"}
-              className="rounded-xl bg-axion-500 px-4 py-2 text-sm font-medium text-white shadow-lg shadow-axion-500/20 transition hover:bg-axion-400 disabled:cursor-not-allowed disabled:opacity-70"
-            >
-              {isConnecting ? "Connecting..." : "Connect Wallet"}
-            </button>
+            /* ── Disconnected state: wallet picker ──────────────────────── */
+            <div className="relative" ref={walletPickerRef}>
+              <button
+                id="navbar-connect-wallet"
+                type="button"
+                onClick={() => {
+                  if (availableWallets.length === 1) {
+                    onConnect(availableWallets[0].id);
+                  } else {
+                    setIsPickerOpen((v) => !v);
+                  }
+                }}
+                disabled={isConnecting}
+                aria-label={isConnecting ? "Connecting to Stellar wallet" : "Connect Stellar wallet"}
+                aria-haspopup={availableWallets.length > 1 ? "true" : undefined}
+                aria-expanded={availableWallets.length > 1 ? isPickerOpen : undefined}
+                className="rounded-xl bg-axion-500 px-4 py-2 text-sm font-medium text-white shadow-lg shadow-axion-500/20 transition hover:bg-axion-400 disabled:cursor-not-allowed disabled:opacity-70"
+              >
+                {isConnecting ? "Connecting…" : "Connect Wallet"}
+              </button>
+
+              {/* Wallet picker dropdown */}
+              {isPickerOpen && !isConnecting && (
+                <div
+                  id="navbar-wallet-picker"
+                  role="menu"
+                  aria-labelledby="navbar-connect-wallet"
+                  className="absolute right-0 mt-2 w-64 origin-top-right rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 shadow-xl ring-1 ring-black/5 dark:ring-white/5 z-50 overflow-hidden"
+                >
+                  <p className="px-4 pt-3 pb-1 text-xs font-medium text-slate-400 dark:text-slate-500 uppercase tracking-wider">
+                    Choose a wallet
+                  </p>
+                  <div className="px-2 pb-2 space-y-0.5">
+                    {availableWallets.map((w) => {
+                      const available = walletAvailability[w.id] ?? true;
+                      return (
+                        <button
+                          key={w.id}
+                          id={`navbar-connect-${w.id}`}
+                          type="button"
+                          role="menuitem"
+                          onClick={async () => {
+                            setIsPickerOpen(false);
+                            await onConnect(w.id);
+                          }}
+                          title={!available ? `Install ${w.label}` : w.description}
+                          className="flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-900/60 transition group"
+                        >
+                          <WalletIcon svg={w.icon} label={w.label} />
+                          <div className="min-w-0 flex-1 text-left">
+                            <div className="font-medium leading-tight">{w.label}</div>
+                            <div className="text-xs text-slate-400 dark:text-slate-500 truncate">
+                              {w.description}
+                            </div>
+                          </div>
+                          {!available && (
+                            <a
+                              href={w.installUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              onClick={(e) => e.stopPropagation()}
+                              className="shrink-0 text-xs text-axion-500 hover:underline"
+                            >
+                              Install
+                            </a>
+                          )}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+            </div>
           )}
         </div>
       </div>

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -1,17 +1,55 @@
+/**
+ * @module contexts/WalletContext
+ *
+ * React context that owns wallet connection state and exposes it to the
+ * component tree.
+ *
+ * Architecture notes
+ * ------------------
+ * This context no longer contains any wallet-library–specific code.  All
+ * adapter logic lives in `src/wallets/` and is accessed through the thin
+ * `src/services/walletService.ts` layer.  To add a new wallet:
+ *   1. Create an adapter in `src/wallets/adapters/`
+ *   2. Register it in `src/wallets/index.ts`
+ *   No changes to this file are required.
+ *
+ * Backward compatibility
+ * ----------------------
+ * The full original API is preserved:
+ *   address, publicKey, network, balance, isConnected, isConnecting, error,
+ *   walletType, connect(walletType), disconnect()
+ *
+ * New additions:
+ *   availableWallets  – WalletMeta[] from the registry (for the picker UI)
+ *   switchWallet(id)  – atomically disconnect + reconnect with a new wallet
+ */
+
 import React, {
   createContext,
-  useContext,
   useCallback,
+  useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   ReactNode,
-  useRef,
 } from "react";
+
 import { StellarNetwork, NETWORK } from "@/utils/networkConfig";
 import { notify } from "@/utils/notifications";
+import { WalletId, WalletMeta } from "@/types/wallet";
+import {
+  connectWallet,
+  disconnectWallet,
+  getAvailableWallets,
+  pollSession,
+  restoreSession,
+  switchWallet as switchWalletService,
+} from "@/services/walletService";
 
-type WalletType = "freighter" | "albedo";
+// ---------------------------------------------------------------------------
+// State shape
+// ---------------------------------------------------------------------------
 
 type WalletState = {
   address: string | null;
@@ -19,38 +57,55 @@ type WalletState = {
   balance: string | null;
   isConnecting: boolean;
   error: string | null;
-  walletType: WalletType | null;
+  walletType: WalletId | null;
 };
 
+// ---------------------------------------------------------------------------
+// Context type
+// ---------------------------------------------------------------------------
+
 interface WalletContextType {
+  // ── Core state ──────────────────────────────────────────────────────────
   address: string | null;
-  publicKey: string | null; // Alias for acceptance criteria
+  /** Alias for `address` — kept for backward compatibility. */
+  publicKey: string | null;
   network: StellarNetwork;
   balance: string | null;
   isConnected: boolean;
   isConnecting: boolean;
   error: string | null;
-  walletType: WalletType | null;
-  connect: (walletType: WalletType) => Promise<void>;
+  /** Which wallet adapter is currently active. */
+  walletType: WalletId | null;
+
+  // ── Registry ─────────────────────────────────────────────────────────────
+  /** All wallets registered in the provider registry. Used by the picker UI. */
+  availableWallets: WalletMeta[];
+
+  // ── Actions ───────────────────────────────────────────────────────────────
+  /**
+   * Connect to the given wallet.
+   * @param walletType - A registered `WalletId` (e.g. "freighter" | "albedo")
+   */
+  connect: (walletType: WalletId) => Promise<void>;
   disconnect: () => void;
+  /**
+   * Atomically disconnect the current wallet and connect a new one.
+   * No-op if `newWalletId` equals the currently active wallet.
+   */
+  switchWallet: (newWalletId: WalletId) => Promise<void>;
 }
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
 
 const WalletContext = createContext<WalletContextType | undefined>(undefined);
 
-async function loadFreighter() {
-  const mod = await import("@stellar/freighter-api");
-  return mod;
-}
+// ---------------------------------------------------------------------------
+// Balance helper
+// ---------------------------------------------------------------------------
 
-async function loadAlbedo() {
-  const mod = await import("@albedo-link/intent");
-  return mod.default;
-}
-
-async function fetchBalance(
-  address: string,
-  network: StellarNetwork,
-): Promise<string> {
+async function fetchBalance(address: string, network: StellarNetwork): Promise<string> {
   try {
     const horizonUrl =
       network === "mainnet"
@@ -58,9 +113,7 @@ async function fetchBalance(
         : "https://horizon-testnet.stellar.org";
 
     const response = await fetch(`${horizonUrl}/accounts/${address}`);
-    if (!response.ok) {
-      throw new Error("Failed to fetch account");
-    }
+    if (!response.ok) throw new Error("Failed to fetch account");
 
     const data = await response.json();
     const xlmBalance = data.balances?.find(
@@ -71,6 +124,10 @@ async function fetchBalance(
     return "0";
   }
 }
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
 
 export function WalletProvider({ children }: { children: ReactNode }) {
   const [state, setState] = useState<WalletState>({
@@ -86,7 +143,10 @@ export function WalletProvider({ children }: { children: ReactNode }) {
 
   const isConnected = useMemo(() => Boolean(state.address), [state.address]);
 
-  // Fetch balance when address changes
+  /** All registered wallets — memoised once because the registry is static. */
+  const availableWallets = useMemo<WalletMeta[]>(() => getAvailableWallets(), []);
+
+  // ── Fetch balance whenever address changes ────────────────────────────────
   useEffect(() => {
     if (!state.address) {
       setState((s) => ({ ...s, balance: null }));
@@ -96,53 +156,28 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     let cancelled = false;
     (async () => {
       const balance = await fetchBalance(state.address!, state.network);
-      if (!cancelled) {
-        setState((s) => ({ ...s, balance }));
-      }
+      if (!cancelled) setState((s) => ({ ...s, balance }));
     })();
 
-    return () => {
-      cancelled = true;
-    };
+    return () => { cancelled = true; };
   }, [state.address, state.network]);
 
-  // Poll for account/network changes
+  // ── Poll for account / network changes via the service layer ─────────────
   useEffect(() => {
     if (!state.address || !state.walletType) return;
 
+    const walletId = state.walletType;
     const checkForChanges = async () => {
-      try {
-        if (state.walletType === "freighter") {
-          const freighter = await loadFreighter();
-          const currentAddress = await freighter.getPublicKey();
-          const currentNetwork = await freighter.getNetwork();
+      const session = await pollSession(walletId);
+      if (!session) return;
 
-          const networkMap: Record<string, StellarNetwork> = {
-            PUBLIC: "mainnet",
-            TESTNET: "testnet",
-            FUTURENET: "futurenet",
-          };
-
-          const mappedNetwork = networkMap[currentNetwork] ?? "testnet";
-
-          if (
-            currentAddress !== state.address ||
-            mappedNetwork !== state.network
-          ) {
-            setState((s) => ({
-              ...s,
-              address: currentAddress,
-              network: mappedNetwork,
-            }));
-          }
-        }
-      } catch {
-        // Ignore polling errors
+      const { address, network } = session;
+      if (address !== state.address || network !== state.network) {
+        setState((s) => ({ ...s, address, network }));
       }
     };
 
     pollingRef.current = setInterval(checkForChanges, 5000);
-
     return () => {
       if (pollingRef.current) {
         clearInterval(pollingRef.current);
@@ -151,90 +186,41 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     };
   }, [state.address, state.walletType, state.network]);
 
-  // Check for existing connection on mount
+  // ── Restore an existing session on mount ─────────────────────────────────
   useEffect(() => {
+    if (typeof window === "undefined") return;
+
     let cancelled = false;
     (async () => {
-      if (typeof window === "undefined") return;
-      try {
-        const freighter = await loadFreighter();
-        if (await freighter.isConnected() && await freighter.isAllowed()) {
-          const address = await freighter.getPublicKey();
-          const network = await freighter.getNetwork();
-
-          const networkMap: Record<string, StellarNetwork> = {
-            PUBLIC: "mainnet",
-            TESTNET: "testnet",
-            FUTURENET: "futurenet",
-          };
-
-          const mappedNetwork = networkMap[network] ?? "testnet";
-
-          if (!cancelled) {
-            setState((s) => ({
-              ...s,
-              address,
-              network: mappedNetwork,
-              walletType: "freighter",
-              error: null,
-            }));
-          }
-        }
-      } catch {
-        if (!cancelled) {
-          setState((s) => ({ ...s, address: null, walletType: null }));
-        }
+      const session = await restoreSession();
+      if (!cancelled && session) {
+        setState((s) => ({
+          ...s,
+          address: session.address,
+          network: session.network,
+          walletType: session.walletId,
+          error: null,
+        }));
       }
     })();
 
-    return () => {
-      cancelled = true;
-    };
+    return () => { cancelled = true; };
   }, []);
 
-  const connect = useCallback(async (walletType: WalletType) => {
+  // ── connect ───────────────────────────────────────────────────────────────
+  const connect = useCallback(async (walletType: WalletId) => {
     setState((s) => ({ ...s, isConnecting: true, error: null }));
     try {
-      if (typeof window === "undefined")
-        throw new Error("Wallet is only available in the browser.");
-
-      let address: string;
-      let mappedNetwork: StellarNetwork = NETWORK;
-
-      if (walletType === "freighter") {
-        const freighter = await loadFreighter();
-        if (!(await freighter.isConnected())) {
-          throw new Error("Freighter wallet not detected.");
-        }
-        await freighter.setAllowed();
-        address = await freighter.getPublicKey();
-        const network = await freighter.getNetwork();
-
-        const networkMap: Record<string, StellarNetwork> = {
-          PUBLIC: "mainnet",
-          TESTNET: "testnet",
-          FUTURENET: "futurenet",
-        };
-        mappedNetwork = networkMap[network] ?? "testnet";
-      } else if (walletType === "albedo") {
-        const albedo = await loadAlbedo();
-        const result = await albedo.publicKey({});
-        address = result.pubkey;
-        mappedNetwork = NETWORK;
-      } else {
-        throw new Error("Unsupported wallet type");
-      }
-
+      const session = await connectWallet(walletType);
       setState({
-        address,
-        network: mappedNetwork,
+        address: session.address,
+        network: session.network,
         balance: null,
         isConnecting: false,
         error: null,
-        walletType,
+        walletType: session.walletId,
       });
-
-      notify.success('Wallet Connected', `Successfully connected to ${walletType} wallet.`);
+      notify.success("Wallet Connected", `Successfully connected to ${walletType}.`);
     } catch (e) {
       const message = e instanceof Error ? e.message : "Failed to connect wallet.";
       setState((s) => ({
@@ -244,16 +230,18 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         error: message,
         walletType: null,
       }));
-      notify.error('Connection Failed', message);
+      notify.error("Connection Failed", message);
     }
   }, []);
 
+  // ── disconnect ────────────────────────────────────────────────────────────
   const disconnect = useCallback(() => {
     if (pollingRef.current) {
       clearInterval(pollingRef.current);
       pollingRef.current = null;
     }
 
+    const currentWalletType = state.walletType;
     setState({
       address: null,
       network: NETWORK,
@@ -262,10 +250,47 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       error: null,
       walletType: null,
     });
-    
-    notify.success('Wallet Disconnected', 'You have been disconnected from your wallet.');
-  }, []);
 
+    if (currentWalletType) {
+      disconnectWallet(currentWalletType).catch(() => {/* swallow */});
+    }
+
+    notify.success("Wallet Disconnected", "You have been disconnected from your wallet.");
+  }, [state.walletType]);
+
+  // ── switchWallet ──────────────────────────────────────────────────────────
+  const switchWallet = useCallback(
+    async (newWalletId: WalletId) => {
+      if (newWalletId === state.walletType) return;
+
+      setState((s) => ({ ...s, isConnecting: true, error: null }));
+      try {
+        const session = await switchWalletService(state.walletType, newWalletId);
+        setState({
+          address: session.address,
+          network: session.network,
+          balance: null,
+          isConnecting: false,
+          error: null,
+          walletType: session.walletId,
+        });
+        notify.success("Wallet Switched", `Now connected to ${newWalletId}.`);
+      } catch (e) {
+        const message = e instanceof Error ? e.message : "Failed to switch wallet.";
+        setState((s) => ({
+          ...s,
+          isConnecting: false,
+          address: null,
+          error: message,
+          walletType: null,
+        }));
+        notify.error("Switch Failed", message);
+      }
+    },
+    [state.walletType],
+  );
+
+  // ── Context value ─────────────────────────────────────────────────────────
   const value = useMemo<WalletContextType>(
     () => ({
       address: state.address,
@@ -276,16 +301,22 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       isConnecting: state.isConnecting,
       error: state.error,
       walletType: state.walletType,
+      availableWallets,
       connect,
       disconnect,
+      switchWallet,
     }),
-    [state, isConnected, connect, disconnect],
+    [state, isConnected, availableWallets, connect, disconnect, switchWallet],
   );
 
   return (
     <WalletContext.Provider value={value}>{children}</WalletContext.Provider>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
 
 export function useWalletContext() {
   const context = useContext(WalletContext);

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -1,1 +1,19 @@
-export { useWalletContext, useWallet, WalletProvider } from '@/contexts/WalletContext';
+/**
+ * @module hooks/useWallet
+ *
+ * Convenience re-exports from the wallet context and provider registry.
+ *
+ * Consuming components should import from this path rather than from the
+ * internal context module directly, keeping the import surface stable as
+ * the implementation evolves.
+ *
+ * Available via this module:
+ *   useWalletContext / useWallet — React hook that returns the full wallet context
+ *   WalletProvider              — React provider component
+ *
+ * Registry / type utilities (imported directly by callers as needed):
+ *   @/wallets     — walletRegistry, adapters, types
+ *   @/types/wallet — WalletId, WalletMeta, WalletProvider interface
+ *   @/services/walletService — connectWallet, disconnectWallet, switchWallet, etc.
+ */
+export { useWalletContext, useWallet, WalletProvider } from "@/contexts/WalletContext";

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -15,7 +15,7 @@ import { initTelemetry } from "@/utils/telemetry";
 import { GovernanceProvider } from "@/contexts/GovernanceContext";
 
 
-function AppInner({ Component, pageProps }: AppProps) {
+function AppInner(props: AppProps) {
   useEffect(() => {
     initTelemetry();
   }, []);
@@ -28,16 +28,7 @@ function AppInner({ Component, pageProps }: AppProps) {
       <ErrorBoundary>
         <ThemeProvider>
           <WalletProvider>
-            <VaultProviderWrapper>
-            <Component {...pageProps} />
-            <ThemeToggle />
-            <Toaster
-              position="top-right"
-              richColors
-              closeButton
-              duration={4000}
-            />
-          </VaultProviderWrapper>
+            <ProvidersInner {...props} />
           </WalletProvider>
         </ThemeProvider>
       </ErrorBoundary>
@@ -45,16 +36,29 @@ function AppInner({ Component, pageProps }: AppProps) {
   );
 }
 
-
-function VaultProviderWrapper({ children }: { children: React.ReactNode }) {
+/**
+ * Inner wrapper that has access to the WalletContext, so it can pass
+ * `walletAddress` down to GovernanceProvider and VaultProvider.
+ */
+function ProvidersInner({ Component, pageProps }: AppProps) {
   const wallet = useWalletContext();
-  return <VaultProvider walletAddress={wallet.publicKey}>{children}</VaultProvider>;
+
+  return (
+    <GovernanceProvider walletAddress={wallet.address}>
+      <VaultProvider walletAddress={wallet.publicKey}>
+        <Component {...pageProps} />
+        <ThemeToggle />
+        <Toaster
+          position="top-right"
+          richColors
+          closeButton
+          duration={4000}
+        />
+      </VaultProvider>
+    </GovernanceProvider>
+  );
 }
 
 export default function App(props: AppProps) {
-  return <GovernanceProvider walletAddress={wallet.address}>
-  <VaultProviderWrapper>
-    <AppInner {...props} />
-  </VaultProviderWrapper>
-</GovernanceProvider>;
+  return <AppInner {...props} />;
 }

--- a/src/pages/analytics.tsx
+++ b/src/pages/analytics.tsx
@@ -27,8 +27,11 @@ export default function AnalyticsPage() {
           <Navbar
             publicKey={wallet.publicKey}
             isConnecting={wallet.isConnecting}
+            walletType={wallet.walletType}
+            availableWallets={wallet.availableWallets}
             onConnect={wallet.connect}
             onDisconnect={wallet.disconnect}
+            onSwitch={wallet.switchWallet}
           />
           <div className="mx-auto max-w-6xl px-4 sm:px-6 py-6 md:py-8 w-full">
             <h1 className="text-3xl font-bold text-slate-900 dark:text-white mb-2">

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -38,8 +38,11 @@ export default function DashboardPage() {
           <Navbar
             publicKey={wallet.publicKey}
             isConnecting={wallet.isConnecting}
+            walletType={wallet.walletType}
+            availableWallets={wallet.availableWallets}
             onConnect={wallet.connect}
             onDisconnect={wallet.disconnect}
+            onSwitch={wallet.switchWallet}
           />
           <div className="mx-auto max-w-6xl px-4 sm:px-6 py-6 md:py-8 w-full">
             <div className="grid gap-6 grid-cols-1 lg:grid-cols-3">

--- a/src/pages/governance.tsx
+++ b/src/pages/governance.tsx
@@ -44,7 +44,15 @@ export default function GovernancePage() {
       <div className="flex min-h-screen bg-background-primary">
         <Sidebar />
         <div className="flex-1 lg:ml-64">
-          <Navbar />
+          <Navbar
+            publicKey={wallet.publicKey}
+            isConnecting={wallet.isConnecting}
+            walletType={wallet.walletType}
+            availableWallets={wallet.availableWallets}
+            onConnect={wallet.connect}
+            onDisconnect={wallet.disconnect}
+            onSwitch={wallet.switchWallet}
+          />
           <main className="p-4 sm:p-6 lg:p-8">
             <div className="mx-auto max-w-7xl">
               <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">

--- a/src/pages/governance/index.tsx
+++ b/src/pages/governance/index.tsx
@@ -28,8 +28,11 @@ export default function GovernancePage() {
           <Navbar
             publicKey={wallet.publicKey}
             isConnecting={wallet.isConnecting}
+            walletType={wallet.walletType}
+            availableWallets={wallet.availableWallets}
             onConnect={wallet.connect}
             onDisconnect={wallet.disconnect}
+            onSwitch={wallet.switchWallet}
           />
           <div className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 md:py-8">
             <GovernanceDashboard />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,11 +1,68 @@
 import Head from "next/head";
 import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
 
 import { useWalletContext } from "@/hooks/useWallet";
 import { shortenAddress } from "@/utils/contractHelpers";
+import { WalletId, WalletMeta } from "@/types/wallet";
+
+/** Inline SVG icon renderer — wallets ship their own SVG strings. */
+function WalletIcon({ svg, label }: { svg: string; label: string }) {
+  return (
+    <span
+      className="h-5 w-5 shrink-0 [&>svg]:h-full [&>svg]:w-full"
+      aria-hidden="true"
+      dangerouslySetInnerHTML={{ __html: svg }}
+      title={label}
+    />
+  );
+}
 
 export default function HomePage() {
-  const { publicKey, isConnected, isConnecting, connect, disconnect } = useWalletContext();
+  const { publicKey, isConnected, isConnecting, connect, disconnect, availableWallets } =
+    useWalletContext();
+
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [walletAvailability, setWalletAvailability] = useState<Record<string, boolean>>({});
+  const pickerRef = useRef<HTMLDivElement>(null);
+
+  /** Pre-check availability so we can show "Install" links for missing wallets. */
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    let cancelled = false;
+    (async () => {
+      const { isWalletAvailable } = await import("@/services/walletService");
+      const entries = await Promise.all(
+        availableWallets.map(async (w) => {
+          try {
+            const ok = await isWalletAvailable(w.id);
+            return [w.id, ok] as const;
+          } catch {
+            return [w.id, false] as const;
+          }
+        }),
+      );
+      if (!cancelled) setWalletAvailability(Object.fromEntries(entries));
+    })();
+    return () => { cancelled = true; };
+  }, [availableWallets]);
+
+  // Close picker on outside click
+  useEffect(() => {
+    if (!isPickerOpen) return;
+    function handleClick(e: MouseEvent) {
+      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
+        setIsPickerOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [isPickerOpen]);
+
+  function handleConnect(walletId: WalletId) {
+    setIsPickerOpen(false);
+    connect(walletId);
+  }
 
   return (
     <>
@@ -30,6 +87,7 @@ export default function HomePage() {
               Connect your Stellar wallet, deposit into the Axionvera vault, withdraw tokens, claim
               rewards, and track your on-chain activity.
             </p>
+
             <div className="mt-10 flex flex-col gap-3 sm:flex-row sm:items-center">
               {isConnected ? (
                 <>
@@ -57,15 +115,77 @@ export default function HomePage() {
                 </>
               ) : (
                 <>
-                  <button
-                    type="button"
-                    onClick={() => connect('freighter')}
-                    disabled={isConnecting}
-                    aria-label={isConnecting ? "Connecting to Stellar wallet" : "Connect Stellar wallet"}
-                    className="inline-flex items-center justify-center rounded-xl bg-axion-500 px-5 py-3 text-sm font-medium text-white shadow-lg shadow-axion-500/20 transition hover:bg-axion-400 disabled:cursor-not-allowed disabled:opacity-70"
-                  >
-                    {isConnecting ? "Connecting..." : "Connect Wallet"}
-                  </button>
+                  {/* Wallet picker trigger */}
+                  <div className="relative" ref={pickerRef}>
+                    <button
+                      id="home-connect-wallet"
+                      type="button"
+                      onClick={() => {
+                        if (availableWallets.length === 1) {
+                          handleConnect(availableWallets[0].id);
+                        } else {
+                          setIsPickerOpen((v) => !v);
+                        }
+                      }}
+                      disabled={isConnecting}
+                      aria-label={isConnecting ? "Connecting to Stellar wallet" : "Connect Stellar wallet"}
+                      aria-haspopup={availableWallets.length > 1 ? "true" : undefined}
+                      aria-expanded={availableWallets.length > 1 ? isPickerOpen : undefined}
+                      className="inline-flex items-center justify-center gap-2 rounded-xl bg-axion-500 px-5 py-3 text-sm font-medium text-white shadow-lg shadow-axion-500/20 transition hover:bg-axion-400 disabled:cursor-not-allowed disabled:opacity-70"
+                    >
+                      {isConnecting ? "Connecting…" : "Connect Wallet"}
+                    </button>
+
+                    {/* Wallet picker dropdown */}
+                    {isPickerOpen && !isConnecting && (
+                      <div
+                        id="home-wallet-picker"
+                        role="menu"
+                        aria-labelledby="home-connect-wallet"
+                        className="absolute left-0 mt-2 w-72 origin-top-left rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 shadow-xl ring-1 ring-black/5 dark:ring-white/5 z-50 overflow-hidden"
+                      >
+                        <p className="px-4 pt-3 pb-1 text-xs font-medium text-slate-400 dark:text-slate-500 uppercase tracking-wider">
+                          Choose a wallet
+                        </p>
+                        <div className="px-2 pb-2 space-y-0.5">
+                          {availableWallets.map((w: WalletMeta) => {
+                            const available = walletAvailability[w.id] ?? true;
+                            return (
+                              <button
+                                key={w.id}
+                                id={`home-connect-${w.id}`}
+                                type="button"
+                                role="menuitem"
+                                onClick={() => handleConnect(w.id)}
+                                title={!available ? `Install ${w.label}` : w.description}
+                                className="flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-900/60 transition"
+                              >
+                                <WalletIcon svg={w.icon} label={w.label} />
+                                <div className="min-w-0 flex-1 text-left">
+                                  <div className="font-medium leading-tight">{w.label}</div>
+                                  <div className="text-xs text-slate-400 dark:text-slate-500 truncate">
+                                    {w.description}
+                                  </div>
+                                </div>
+                                {!available && (
+                                  <a
+                                    href={w.installUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    onClick={(e) => e.stopPropagation()}
+                                    className="shrink-0 text-xs text-axion-500 hover:underline"
+                                  >
+                                    Install
+                                  </a>
+                                )}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+
                   <a
                     href="https://github.com/Axionvera/axionvera-dashboard"
                     target="_blank"
@@ -79,11 +199,12 @@ export default function HomePage() {
               )}
             </div>
           </div>
+
           <div className="mt-10 grid gap-4 sm:grid-cols-3">
             {[
-              { title: "Wallet", body: "Freighter-style wallet connection and address display." },
+              { title: "Multi-Wallet", body: "Connect via Freighter or Albedo. Switch wallets at any time without losing your session." },
               { title: "Vault", body: "Deposit, withdraw, and claim rewards via an SDK adapter." },
-              { title: "History", body: "Track your latest vault transactions and statuses." }
+              { title: "History", body: "Track your latest vault transactions and statuses." },
             ].map((card) => (
               <div
                 key={card.title}

--- a/src/pages/monitoring.tsx
+++ b/src/pages/monitoring.tsx
@@ -28,8 +28,11 @@ export default function MonitoringPage() {
           <Navbar
             publicKey={wallet.publicKey}
             isConnecting={wallet.isConnecting}
+            walletType={wallet.walletType}
+            availableWallets={wallet.availableWallets}
             onConnect={wallet.connect}
             onDisconnect={wallet.disconnect}
+            onSwitch={wallet.switchWallet}
           />
           <div className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 md:py-8">
             <ProtocolHealthDashboard />

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -51,8 +51,11 @@ export default function ProfilePage() {
         <Navbar
           publicKey={wallet.publicKey}
           isConnecting={wallet.isConnecting}
+          walletType={wallet.walletType}
+          availableWallets={wallet.availableWallets}
           onConnect={wallet.connect}
           onDisconnect={wallet.disconnect}
+          onSwitch={wallet.switchWallet}
         />
         <div className={`transition-all duration-300 ${isOpen ? 'lg:pl-64' : ''}`}>
           <div className="mx-auto max-w-4xl px-6 py-8">

--- a/src/services/walletService.ts
+++ b/src/services/walletService.ts
@@ -1,0 +1,170 @@
+/**
+ * @module services/walletService
+ *
+ * High-level wallet service that wraps the `WalletRegistry` and manages a
+ * single active wallet adapter instance.
+ *
+ * Responsibilities
+ * ----------------
+ * - Expose `getAvailableWallets()` so the UI can discover registered wallets.
+ * - `connectWallet(id)` — resolve adapter → call `connect()` → return session.
+ * - `disconnectWallet()` — call `disconnect()` on the currently active adapter.
+ * - `switchWallet(newId)` — atomically disconnect → connect with a new wallet.
+ * - `restoreSession()` — on mount, check adapters for an existing session.
+ *
+ * This service is stateless at the module level; state is owned by
+ * `WalletContext`.  The service only orchestrates adapter lifecycles and
+ * translates adapter errors into user-friendly messages.
+ *
+ * Consistent with `src/services/protocolHealth.ts`, this file contains only
+ * plain async functions — no React hooks or context.
+ */
+
+// Importing from `@/wallets` triggers registry bootstrap (side effect).
+import { walletRegistry, WalletAdapterError, WalletId, WalletMeta, WalletProvider } from "@/wallets";
+import { StellarNetwork } from "@/utils/networkConfig";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface WalletSession {
+  /** The connected Stellar public key. */
+  address: string;
+  /** The network reported by the wallet. */
+  network: StellarNetwork;
+  /** Which wallet adapter produced this session. */
+  walletId: WalletId;
+}
+
+// ---------------------------------------------------------------------------
+// Internal adapter cache
+// ---------------------------------------------------------------------------
+
+/**
+ * Cache of instantiated adapters keyed by `WalletId`.
+ * Adapters are created once and reused to avoid repeated extension pings.
+ */
+const adapterCache = new Map<WalletId, WalletProvider>();
+
+function getAdapter(id: WalletId): WalletProvider {
+  if (!adapterCache.has(id)) {
+    adapterCache.set(id, walletRegistry.createAdapter(id));
+  }
+  return adapterCache.get(id)!;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the static metadata for every wallet registered in the registry.
+ * The UI uses this to render the wallet-picker dropdown.
+ */
+export function getAvailableWallets(): WalletMeta[] {
+  return walletRegistry.list();
+}
+
+/**
+ * Check whether a specific wallet is installed / accessible.
+ * Use this to show an "Install" link instead of "Connect" in the picker.
+ */
+export async function isWalletAvailable(id: WalletId): Promise<boolean> {
+  try {
+    return await getAdapter(id).isAvailable();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Connect to the wallet identified by `id`.
+ *
+ * @throws {WalletAdapterError} on user rejection or wallet unavailability.
+ * @throws {Error} for unexpected failures (re-thrown with context).
+ */
+export async function connectWallet(id: WalletId): Promise<WalletSession> {
+  const adapter = getAdapter(id);
+  try {
+    const { address, network } = await adapter.connect();
+    return { address, network, walletId: id };
+  } catch (error) {
+    if (error instanceof WalletAdapterError) throw error;
+    throw new WalletAdapterError(
+      "UNKNOWN",
+      `Failed to connect to ${id}: ${error instanceof Error ? error.message : String(error)}`,
+      error,
+    );
+  }
+}
+
+/**
+ * Disconnect the wallet identified by `id`.
+ * Always resolves — errors are swallowed to ensure UI state is reset.
+ */
+export async function disconnectWallet(id: WalletId): Promise<void> {
+  try {
+    const adapter = getAdapter(id);
+    await adapter.disconnect();
+  } catch {
+    // Disconnect must never throw.
+  }
+}
+
+/**
+ * Switch from the currently active wallet to a different one.
+ *
+ * Disconnects `currentId` first, then connects `newId`.
+ * If the connect step fails the disconnect is still committed (no rollback).
+ *
+ * @throws {WalletAdapterError} propagated from `connectWallet`.
+ */
+export async function switchWallet(
+  currentId: WalletId | null,
+  newId: WalletId,
+): Promise<WalletSession> {
+  if (currentId && currentId !== newId) {
+    await disconnectWallet(currentId);
+  }
+  return connectWallet(newId);
+}
+
+/**
+ * Attempt to restore an existing session without user interaction.
+ *
+ * Iterates registered wallets in registration order and returns the first
+ * active session found (e.g. Freighter extension already permitted this site).
+ *
+ * Returns `null` when no session can be restored.
+ */
+export async function restoreSession(): Promise<WalletSession | null> {
+  const ids = walletRegistry.ids();
+  for (const id of ids) {
+    try {
+      const adapter = getAdapter(id);
+      const session = await adapter.getActiveSession();
+      if (session) {
+        return { ...session, walletId: id };
+      }
+    } catch {
+      // Continue to next adapter.
+    }
+  }
+  return null;
+}
+
+/**
+ * Poll an active adapter for account/network changes.
+ * Returns `null` when the adapter reports the session has ended.
+ */
+export async function pollSession(id: WalletId): Promise<WalletSession | null> {
+  try {
+    const adapter = getAdapter(id);
+    const session = await adapter.getActiveSession();
+    if (!session) return null;
+    return { ...session, walletId: id };
+  } catch {
+    return null;
+  }
+}

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -1,0 +1,19 @@
+/**
+ * @module types/wallet
+ *
+ * Public-facing re-exports of wallet types.
+ *
+ * Consumers throughout the app (pages, components, hooks) should import from
+ * this path (`@/types/wallet`) rather than from the internal implementation
+ * (`@/wallets/types`) so the internal module layout can evolve independently.
+ */
+
+export type {
+  WalletId,
+  WalletMeta,
+  WalletProvider,
+  WalletCapabilities,
+  WalletProviderFactory,
+} from "@/wallets/types";
+
+export { WalletAdapterError } from "@/wallets/types";

--- a/src/wallets/adapters/albedo.ts
+++ b/src/wallets/adapters/albedo.ts
@@ -1,0 +1,150 @@
+/**
+ * @module wallets/adapters/albedo
+ *
+ * Albedo wallet adapter.
+ *
+ * Albedo (https://albedo.link) is a web-based Stellar intent service.
+ * It does not require a browser extension — users are redirected to the Albedo
+ * web app which handles signing and returns results via a popup / intent flow.
+ *
+ * Capabilities
+ * ------------
+ * - publicKey       ✓
+ * - signTransaction ✗  (Albedo uses an intent-based flow; raw tx signing is
+ *                        handled through the Albedo popup, not the adapter)
+ * - signAuthEntry   ✗
+ *
+ * Because Albedo is always "available" (it's web-based), `isAvailable()`
+ * always returns `true` in browser environments.
+ */
+
+import { NETWORK, StellarNetwork } from "@/utils/networkConfig";
+import { WalletAdapterError, WalletMeta, WalletProvider } from "../types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Lazy-load the Albedo intent library to avoid bundling it when not used. */
+async function loadAlbedo() {
+  const mod = await import("@albedo-link/intent");
+  return mod.default;
+}
+
+// ---------------------------------------------------------------------------
+// Session storage key
+// ---------------------------------------------------------------------------
+
+const ALBEDO_SESSION_KEY = "axionvera:albedo:pubkey";
+
+// ---------------------------------------------------------------------------
+// Metadata
+// ---------------------------------------------------------------------------
+
+const ALBEDO_META: WalletMeta = {
+  id: "albedo",
+  label: "Albedo",
+  description: "Web-based Stellar wallet — no extension required.",
+  installUrl: "https://albedo.link",
+  icon: `<svg viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="40" height="40" rx="10" fill="#1A1A2E"/>
+    <circle cx="20" cy="20" r="9" fill="none" stroke="#E94560" strokeWidth="2.5"/>
+    <circle cx="20" cy="20" r="4" fill="#E94560"/>
+    <path d="M20 5v4M20 31v4M5 20h4M31 20h4" stroke="#E94560" strokeWidth="2" strokeLinecap="round"/>
+  </svg>`,
+  capabilities: {
+    publicKey: true,
+    signTransaction: false,
+    signAuthEntry: false,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+export class AlbedoAdapter implements WalletProvider {
+  readonly meta: WalletMeta = ALBEDO_META;
+
+  /** Albedo is web-based; it is always "available" in browser environments. */
+  async isAvailable(): Promise<boolean> {
+    return typeof window !== "undefined";
+  }
+
+  /**
+   * We store the Albedo public key in sessionStorage after a successful
+   * connect so the session can be restored on page refresh.
+   */
+  async isConnected(): Promise<boolean> {
+    if (typeof window === "undefined") return false;
+    const stored = sessionStorage.getItem(ALBEDO_SESSION_KEY);
+    return Boolean(stored);
+  }
+
+  async connect(): Promise<{ address: string; network: StellarNetwork }> {
+    if (typeof window === "undefined") {
+      throw new WalletAdapterError(
+        "NOT_AVAILABLE",
+        "Albedo is only available in the browser.",
+      );
+    }
+
+    let albedo: Awaited<ReturnType<typeof loadAlbedo>>;
+    try {
+      albedo = await loadAlbedo();
+    } catch (cause) {
+      throw new WalletAdapterError(
+        "NOT_AVAILABLE",
+        "Failed to load the Albedo intent library.",
+        cause,
+      );
+    }
+
+    let result: { pubkey: string };
+    try {
+      result = await albedo.publicKey({});
+    } catch (cause) {
+      // Albedo throws when the user closes the popup or rejects the request.
+      throw new WalletAdapterError(
+        "USER_REJECTED",
+        "User rejected the Albedo authorization request.",
+        cause,
+      );
+    }
+
+    const address = result.pubkey;
+
+    // Persist session for page refreshes.
+    try {
+      sessionStorage.setItem(ALBEDO_SESSION_KEY, address);
+    } catch {
+      // sessionStorage may be blocked (e.g. private mode). Non-fatal.
+    }
+
+    return { address, network: NETWORK };
+  }
+
+  async disconnect(): Promise<void> {
+    try {
+      sessionStorage.removeItem(ALBEDO_SESSION_KEY);
+    } catch {
+      // Ignore storage errors during disconnect.
+    }
+  }
+
+  async getActiveSession(): Promise<{ address: string; network: StellarNetwork } | null> {
+    if (typeof window === "undefined") return null;
+    try {
+      const address = sessionStorage.getItem(ALBEDO_SESSION_KEY);
+      if (!address) return null;
+      return { address, network: NETWORK };
+    } catch {
+      return null;
+    }
+  }
+}
+
+/** Factory function used by the wallet registry. */
+export function createAlbedoAdapter(): WalletProvider {
+  return new AlbedoAdapter();
+}

--- a/src/wallets/adapters/freighter.ts
+++ b/src/wallets/adapters/freighter.ts
@@ -1,0 +1,173 @@
+/**
+ * @module wallets/adapters/freighter
+ *
+ * Freighter wallet adapter.
+ *
+ * Freighter (https://www.freighter.app) is a browser extension that provides
+ * the `@stellar/freighter-api` package.  This adapter wraps that package
+ * behind the common `WalletProvider` interface so the rest of the app is
+ * decoupled from Freighter specifics.
+ *
+ * Capabilities
+ * ------------
+ * - publicKey       ✓
+ * - signTransaction ✓  (Freighter exposes `signTransaction`)
+ * - signAuthEntry   ✗  (not yet exposed via the browser extension API)
+ */
+
+import { StellarNetwork } from "@/utils/networkConfig";
+import { WalletAdapterError, WalletMeta, WalletProvider } from "../types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Lazy-load the Freighter API to avoid bundling it when not used. */
+async function loadFreighter() {
+  const mod = await import("@stellar/freighter-api");
+  return mod;
+}
+
+/**
+ * Map Freighter network strings → `StellarNetwork` discriminated union.
+ * Freighter returns "PUBLIC", "TESTNET", or "FUTURENET".
+ */
+const FREIGHTER_NETWORK_MAP: Record<string, StellarNetwork> = {
+  PUBLIC: "mainnet",
+  TESTNET: "testnet",
+  FUTURENET: "futurenet",
+};
+
+function mapFreighterNetwork(raw: string): StellarNetwork {
+  return FREIGHTER_NETWORK_MAP[raw] ?? "testnet";
+}
+
+// ---------------------------------------------------------------------------
+// Metadata
+// ---------------------------------------------------------------------------
+
+const FREIGHTER_META: WalletMeta = {
+  id: "freighter",
+  label: "Freighter",
+  description: "Official Stellar browser extension wallet by the SDF.",
+  installUrl: "https://www.freighter.app",
+  icon: `<svg viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="40" height="40" rx="10" fill="#5B4FE8"/>
+    <path d="M10 20C10 14.477 14.477 10 20 10s10 4.477 10 10-4.477 10-10 10S10 25.523 10 20z" fill="#fff" fill-opacity=".15"/>
+    <path d="M14 20h12M20 14v12" stroke="#fff" strokeWidth="2.5" strokeLinecap="round"/>
+  </svg>`,
+  capabilities: {
+    publicKey: true,
+    signTransaction: true,
+    signAuthEntry: false,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+export class FreighterAdapter implements WalletProvider {
+  readonly meta: WalletMeta = FREIGHTER_META;
+
+  async isAvailable(): Promise<boolean> {
+    if (typeof window === "undefined") return false;
+    try {
+      const freighter = await loadFreighter();
+      return freighter.isConnected();
+    } catch {
+      return false;
+    }
+  }
+
+  async isConnected(): Promise<boolean> {
+    if (typeof window === "undefined") return false;
+    try {
+      const freighter = await loadFreighter();
+      const connected = await freighter.isConnected();
+      const allowed = await freighter.isAllowed();
+      return connected && allowed;
+    } catch {
+      return false;
+    }
+  }
+
+  async connect(): Promise<{ address: string; network: StellarNetwork }> {
+    if (typeof window === "undefined") {
+      throw new WalletAdapterError(
+        "NOT_AVAILABLE",
+        "Freighter is only available in the browser.",
+      );
+    }
+
+    let freighter: Awaited<ReturnType<typeof loadFreighter>>;
+    try {
+      freighter = await loadFreighter();
+    } catch (cause) {
+      throw new WalletAdapterError(
+        "NOT_AVAILABLE",
+        "Failed to load the Freighter API.",
+        cause,
+      );
+    }
+
+    const available = await freighter.isConnected();
+    if (!available) {
+      throw new WalletAdapterError(
+        "NOT_AVAILABLE",
+        "Freighter wallet extension is not installed. Please install it from freighter.app.",
+      );
+    }
+
+    try {
+      await freighter.setAllowed();
+    } catch (cause) {
+      throw new WalletAdapterError(
+        "USER_REJECTED",
+        "User rejected the Freighter connection request.",
+        cause,
+      );
+    }
+
+    let address: string;
+    let rawNetwork: string;
+
+    try {
+      address = await freighter.getPublicKey();
+      rawNetwork = await freighter.getNetwork();
+    } catch (cause) {
+      throw new WalletAdapterError(
+        "UNKNOWN",
+        "Failed to retrieve account details from Freighter.",
+        cause,
+      );
+    }
+
+    return { address, network: mapFreighterNetwork(rawNetwork) };
+  }
+
+  async disconnect(): Promise<void> {
+    // Freighter does not expose a programmatic disconnect API.
+    // We simply treat clearing local state as a disconnect.
+  }
+
+  async getActiveSession(): Promise<{ address: string; network: StellarNetwork } | null> {
+    if (typeof window === "undefined") return null;
+    try {
+      const freighter = await loadFreighter();
+      if (!(await freighter.isConnected()) || !(await freighter.isAllowed())) {
+        return null;
+      }
+      const address = await freighter.getPublicKey();
+      const rawNetwork = await freighter.getNetwork();
+      return { address, network: mapFreighterNetwork(rawNetwork) };
+    } catch {
+      return null;
+    }
+  }
+}
+
+/** Factory function used by the wallet registry. */
+export function createFreighterAdapter(): WalletProvider {
+  return new FreighterAdapter();
+}

--- a/src/wallets/index.ts
+++ b/src/wallets/index.ts
@@ -1,0 +1,39 @@
+/**
+ * @module wallets
+ *
+ * Public barrel export for the Axionvera wallet layer.
+ *
+ * Importing this module has the important **side effect** of registering
+ * the built-in wallet adapters (Freighter, Albedo) into the singleton
+ * `walletRegistry`.  You must import this module — directly or transitively
+ * via `src/services/walletService.ts` — before calling `walletRegistry.list()`
+ * or `walletRegistry.createAdapter()`.
+ *
+ * To add a new wallet:
+ * 1. Create `src/wallets/adapters/<name>.ts` implementing `WalletProvider`.
+ * 2. Add the wallet id to the `WalletId` union in `src/wallets/types.ts`.
+ * 3. Register the factory here with `walletRegistry.register(...)`.
+ * 4. Document the new adapter in `docs/wallet-architecture.md`.
+ *
+ * No changes to `WalletContext`, `Navbar`, or any page are required.
+ */
+
+// Re-export everything callers might need.
+export type { WalletId, WalletMeta, WalletProvider, WalletCapabilities, WalletProviderFactory } from "./types";
+export { WalletAdapterError } from "./types";
+export { walletRegistry } from "./registry";
+
+// Adapters (re-exported for testing / direct instantiation)
+export { FreighterAdapter, createFreighterAdapter } from "./adapters/freighter";
+export { AlbedoAdapter, createAlbedoAdapter } from "./adapters/albedo";
+
+// ---------------------------------------------------------------------------
+// Bootstrap — register built-in adapters
+// ---------------------------------------------------------------------------
+
+import { walletRegistry } from "./registry";
+import { createFreighterAdapter } from "./adapters/freighter";
+import { createAlbedoAdapter } from "./adapters/albedo";
+
+walletRegistry.register("freighter", createFreighterAdapter);
+walletRegistry.register("albedo", createAlbedoAdapter);

--- a/src/wallets/registry.ts
+++ b/src/wallets/registry.ts
@@ -1,0 +1,122 @@
+/**
+ * @module wallets/registry
+ *
+ * Singleton `WalletRegistry` that maps `WalletId` → `WalletProviderFactory`.
+ *
+ * Usage
+ * -----
+ * ```ts
+ * // Register a new adapter (done once, in src/wallets/index.ts)
+ * walletRegistry.register("myWallet", () => new MyWalletAdapter());
+ *
+ * // Retrieve registered metadata (used by the UI wallet-picker)
+ * const wallets = walletRegistry.list(); // WalletMeta[]
+ *
+ * // Instantiate an adapter on demand
+ * const adapter = walletRegistry.createAdapter("freighter");
+ * ```
+ *
+ * Design notes
+ * ------------
+ * - Adapters are instantiated **lazily** (on `createAdapter`) to avoid
+ *   side effects at import time (e.g. Freighter pings the extension on init).
+ * - `register()` is idempotent — registering the same id twice overwrites
+ *   the previous factory, which is useful for testing / mocking.
+ */
+
+import { WalletId, WalletMeta, WalletProvider, WalletProviderFactory } from "./types";
+
+// ---------------------------------------------------------------------------
+// Registry implementation
+// ---------------------------------------------------------------------------
+
+class WalletRegistry {
+  private readonly factories = new Map<WalletId, WalletProviderFactory>();
+
+  /**
+   * Register a wallet adapter factory under the given `id`.
+   * Call this once per wallet, typically inside `src/wallets/index.ts`.
+   *
+   * @param id       - Stable identifier (must extend `WalletId`)
+   * @param factory  - Zero-arg function that returns a fresh adapter instance
+   */
+  register(id: WalletId, factory: WalletProviderFactory): void {
+    this.factories.set(id, factory);
+  }
+
+  /**
+   * Remove a previously registered wallet.
+   * Primarily useful in unit tests that need a clean registry.
+   */
+  unregister(id: WalletId): void {
+    this.factories.delete(id);
+  }
+
+  /**
+   * Returns `true` when a factory has been registered for `id`.
+   */
+  has(id: WalletId): boolean {
+    return this.factories.has(id);
+  }
+
+  /**
+   * Retrieve the factory for `id`.
+   * Throws if `id` is not registered — always call `has()` first or catch.
+   */
+  get(id: WalletId): WalletProviderFactory {
+    const factory = this.factories.get(id);
+    if (!factory) {
+      throw new Error(
+        `[WalletRegistry] No adapter registered for wallet id "${id}". ` +
+        `Make sure you import "src/wallets/index.ts" before using the registry.`,
+      );
+    }
+    return factory;
+  }
+
+  /**
+   * Instantiate a fresh adapter for `id`.
+   * Each call returns a **new** instance — callers should cache the result
+   * if they need a long-lived adapter reference (e.g. inside `walletService`).
+   */
+  createAdapter(id: WalletId): WalletProvider {
+    return this.get(id)();
+  }
+
+  /**
+   * Returns the static `WalletMeta` for every registered wallet, in
+   * registration order.  Used by the UI to render the wallet-picker.
+   */
+  list(): WalletMeta[] {
+    return Array.from(this.factories.keys()).map((id) => {
+      // Instantiate temporarily just to read meta — cheap, no network calls.
+      const adapter = this.get(id)();
+      return adapter.meta;
+    });
+  }
+
+  /**
+   * Returns all registered wallet ids.
+   */
+  ids(): WalletId[] {
+    return Array.from(this.factories.keys());
+  }
+
+  /** @internal For testing only — removes all registered factories. */
+  _reset(): void {
+    this.factories.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton export
+// ---------------------------------------------------------------------------
+
+/**
+ * The application-wide wallet registry.
+ *
+ * Import `src/wallets/index.ts` (not this module directly) to ensure the
+ * built-in adapters are already registered before you call `list()` or
+ * `createAdapter()`.
+ */
+export const walletRegistry = new WalletRegistry();

--- a/src/wallets/types.ts
+++ b/src/wallets/types.ts
@@ -1,0 +1,143 @@
+/**
+ * @module wallets/types
+ *
+ * Core type definitions for the Axionvera multi-wallet provider registry.
+ * Every wallet adapter must implement the `WalletProvider` interface.
+ * The `WalletRegistry` discovers and instantiates adapters via `WalletProviderFactory`.
+ */
+
+import { StellarNetwork } from "@/utils/networkConfig";
+
+// ---------------------------------------------------------------------------
+// Wallet identity
+// ---------------------------------------------------------------------------
+
+/**
+ * Known wallet identifiers. Extend this union by registering a new adapter
+ * in `src/wallets/registry.ts` — no changes to the context or UI are required.
+ */
+export type WalletId = "freighter" | "albedo";
+
+// ---------------------------------------------------------------------------
+// Capabilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Feature flags that describe what a wallet adapter is able to do.
+ * The UI uses these flags to show/hide advanced actions (e.g. transaction signing).
+ */
+export interface WalletCapabilities {
+  /** Adapter can return the user's Stellar public key. */
+  publicKey: boolean;
+  /** Adapter can sign and submit Stellar transactions. */
+  signTransaction: boolean;
+  /** Adapter supports Soroban auth-entry signing (required for contract interactions). */
+  signAuthEntry: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Display metadata
+// ---------------------------------------------------------------------------
+
+/**
+ * Static, display-only metadata for a wallet.
+ * Used to populate the wallet-picker dropdown in the UI.
+ */
+export interface WalletMeta {
+  /** Unique, stable identifier for the wallet. */
+  id: WalletId;
+  /** Human-readable label shown in the UI (e.g. "Freighter"). */
+  label: string;
+  /** Inline SVG string or a URL for the wallet's icon. */
+  icon: string;
+  /** URL users should visit to install the wallet extension / app. */
+  installUrl: string;
+  /** Short description shown as a tooltip or subtitle in the picker. */
+  description: string;
+  /** Feature flags for this wallet. */
+  capabilities: WalletCapabilities;
+}
+
+// ---------------------------------------------------------------------------
+// Provider interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Contract that every wallet adapter must satisfy.
+ *
+ * Implementations live in `src/wallets/adapters/` and are registered via
+ * `WalletRegistry.register()`.  The `WalletContext` never imports an adapter
+ * directly — it only calls methods on this interface.
+ */
+export interface WalletProvider {
+  /** Static metadata describing this wallet. */
+  readonly meta: WalletMeta;
+
+  /**
+   * Returns `true` when the wallet extension / app is available in the current
+   * browser environment.  If `false`, the UI disables the picker option and
+   * directs the user to `meta.installUrl`.
+   */
+  isAvailable(): Promise<boolean>;
+
+  /**
+   * Returns `true` when the user has already granted permission to this app.
+   * Used on mount to restore an existing session without re-prompting.
+   */
+  isConnected(): Promise<boolean>;
+
+  /**
+   * Prompt the user to authorise this app and return their public key.
+   * Throws `WalletAdapterError` on failure.
+   */
+  connect(): Promise<{ address: string; network: StellarNetwork }>;
+
+  /**
+   * Revoke the session / clean up any listeners.
+   * Must not throw — failures should be swallowed silently.
+   */
+  disconnect(): Promise<void>;
+
+  /**
+   * Poll for external account or network changes (e.g. the user switched
+   * accounts inside the wallet extension).  Returns the latest state or
+   * `null` when the wallet is no longer connected.
+   */
+  getActiveSession(): Promise<{ address: string; network: StellarNetwork } | null>;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * A zero-argument constructor for a `WalletProvider`.
+ * The registry stores factories so adapters are instantiated lazily.
+ */
+export type WalletProviderFactory = () => WalletProvider;
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+/**
+ * Typed error thrown by wallet adapters.
+ * Consumers can `instanceof` check to distinguish wallet errors from
+ * generic network / contract errors.
+ */
+export class WalletAdapterError extends Error {
+  constructor(
+    /** Stable machine-readable code. */
+    public readonly code:
+      | "NOT_AVAILABLE"
+      | "NOT_CONNECTED"
+      | "USER_REJECTED"
+      | "NETWORK_MISMATCH"
+      | "UNKNOWN",
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "WalletAdapterError";
+  }
+}

--- a/tests/components/Navbar.test.tsx
+++ b/tests/components/Navbar.test.tsx
@@ -14,6 +14,34 @@ jest.mock("next/link", () => ({
   )
 }));
 
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ src, alt, ...props }: { src: string; alt: string; [k: string]: unknown }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={src} alt={alt} {...(props as object)} />
+  ),
+}));
+
+/** Minimal wallet metas for test usage */
+const mockAvailableWallets = [
+  {
+    id: "freighter" as const,
+    label: "Freighter",
+    description: "Browser extension wallet",
+    installUrl: "https://freighter.app",
+    icon: "<svg></svg>",
+    capabilities: { publicKey: true, signTransaction: true, signAuthEntry: false },
+  },
+  {
+    id: "albedo" as const,
+    label: "Albedo",
+    description: "Web-based wallet",
+    installUrl: "https://albedo.link",
+    icon: "<svg></svg>",
+    capabilities: { publicKey: true, signTransaction: false, signAuthEntry: false },
+  },
+];
+
 describe("Navbar", () => {
   function renderNavbar(ui: ReactElement) {
     return render(<ThemeProvider>{ui}</ThemeProvider>);
@@ -23,11 +51,19 @@ describe("Navbar", () => {
     const user = userEvent.setup();
     const onConnect = jest.fn(async () => undefined);
     renderNavbar(
-      <Navbar publicKey={null} isConnecting={false} onConnect={onConnect} onDisconnect={jest.fn()} />
+      <Navbar
+        publicKey={null}
+        isConnecting={false}
+        walletType={null}
+        availableWallets={mockAvailableWallets}
+        onConnect={onConnect}
+        onDisconnect={jest.fn()}
+        onSwitch={jest.fn(async () => undefined)}
+      />
     );
 
     await user.click(screen.getByRole("button", { name: /connect stellar wallet/i }));
-    expect(onConnect).toHaveBeenCalledTimes(1);
+    expect(onConnect).toHaveBeenCalledTimes(0); // Picker opens on first click with multiple wallets
   });
 
   test("shows disconnect button when connected", async () => {
@@ -37,8 +73,11 @@ describe("Navbar", () => {
       <Navbar
         publicKey="GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
         isConnecting={false}
+        walletType="freighter"
+        availableWallets={mockAvailableWallets}
         onConnect={jest.fn(async () => undefined)}
         onDisconnect={onDisconnect}
+        onSwitch={jest.fn(async () => undefined)}
       />
     );
 


### PR DESCRIPTION
Closes #222 

## Summary

Implements a pluggable **wallet provider registry** so the dashboard can
support multiple Stellar wallets with runtime selection and provider switching.
New wallets can be added by dropping a single file — no changes to
`WalletContext`, `Navbar`, or any page are required.

---

## Motivation

Protocol adoption depends on broad wallet compatibility. The previous
implementation hard-coded Freighter and Albedo directly inside
`WalletContext.tsx` using an `if/else` chain. Adding a third wallet
required touching the context, every page that renders `<Navbar>`, and test
files.

---

## Changes

### New: `src/wallets/` — Wallet abstraction layer

| File | Purpose |
|---|---|
| `types.ts` | `WalletProvider` interface, `WalletMeta`, `WalletId`, `WalletCapabilities`, `WalletAdapterError` |
| `registry.ts` | `WalletRegistry` singleton — `register()`, `list()`, `createAdapter()` |
| `adapters/freighter.ts` | Freighter browser-extension adapter |
| `adapters/albedo.ts` | Albedo web-intent adapter (session-restored via `sessionStorage`) |
| `index.ts` | Barrel export + bootstraps built-in adapters as a side-effect import |

### New: `src/services/walletService.ts`

Plain async functions — no React:
- `getAvailableWallets()` → `WalletMeta[]`
- `isWalletAvailable(id)` → availability check
- `connectWallet(id)` → connect and return session
- `disconnectWallet(id)` → disconnect (never throws)
- `switchWallet(currentId, newId)` → atomic disconnect → connect
- `restoreSession()` → iterate adapters for an existing session on mount
- `pollSession(id)` → poll active adapter for account/network changes

### New: `src/types/wallet.ts`

Public-facing re-export path for wallet types.

### Modified: `src/contexts/WalletContext.tsx`

- Delegates all adapter logic to `walletService`
- **Backward compatible** — full original API preserved
- New additions: `availableWallets: WalletMeta[]`, `switchWallet(id)`
- Session restore on mount uses `restoreSession()` (covers all registered adapters)

### Modified: `src/components/Navbar.tsx`

- Disconnected state: **wallet-picker dropdown** listing all registered wallets
  - Shows wallet icon + label + description
  - Displays "Install" link for unavailable wallets (extension not present)
- Connected state: shows active wallet icon; "Switch to X" for other wallets

### Modified: `src/pages/index.tsx`

- Same wallet-picker dropdown on the landing page

### Modified: pages & `_app.tsx`

- All pages (`dashboard`, `analytics`, `monitoring`, `profile`, `governance`)
  pass the new `walletType`, `availableWallets`, `onSwitch` Navbar props
- `_app.tsx`: fixed pre-existing bug where `wallet.address` was referenced
  outside the `WalletProvider` tree

### New: `docs/wallet-architecture.md`

Architecture overview covering:
- Registry pattern diagram
- Built-in wallets table
- Step-by-step guide to adding a new adapter
- Capability flags reference
- Migration notes from the old `WalletType` string union

---

## How to Add a New Wallet (post-merge)

1. Create `src/wallets/adapters/<name>.ts` implementing `WalletProvider`
2. Add the id to `WalletId` in `src/wallets/types.ts`
3. Register: `walletRegistry.register("<name>", createXAdapter)` in `src/wallets/index.ts`
4. Document in `docs/wallet-architecture.md`

No changes to context, navbar, or pages required.

---

## Testing

- TypeScript: zero new errors introduced (4 pre-existing errors in unrelated files)
- `tests/components/Navbar.test.tsx` updated for new required props
- Existing jest suite unaffected

---

## Checklist

- [x] Multiple wallets supported (Freighter + Albedo via registry)
- [x] Provider switching works (`switchWallet` in context, "Switch to X" in Navbar)
- [x] Documentation updated (`docs/wallet-architecture.md`, `docs/architecture.md`)
- [x] Hardware wallet implementation — **out of scope** (per issue)
- [x] Feature branch: `feat/multi-wallet-provider-registry`

---

## Wallet Architecture Overview