### PR TITLE
feat: real-time event streaming layer for live dashboard updates (#215)

### DIFF
--- a/src/components/activity/ActivityFeed.tsx
+++ b/src/components/activity/ActivityFeed.tsx
@@ -1,0 +1,57 @@
+import { useActivityFeed } from "@/hooks/useActivityFeed";
+import ActivityItem from "./ActivityItem";
+import ConnectionStatusBadge from "./ConnectionStatusBadge";
+
+export interface ActivityFeedProps {
+  /** Disable the live stream (e.g. when the panel is hidden). Default true. */
+  enabled?: boolean;
+  /** Max events to render. */
+  limit?: number;
+}
+
+/**
+ * Live protocol activity feed. Subscribes to the real-time event stream and
+ * renders deposits, withdrawals, rewards and governance actions as they arrive
+ * — no manual refresh required (issue #215).
+ */
+export default function ActivityFeed({ enabled = true, limit = 50 }: ActivityFeedProps) {
+  const { events, status, clear } = useActivityFeed({ enabled });
+  const visible = events.slice(0, limit);
+
+  return (
+    <section
+      aria-label="Live activity feed"
+      className="rounded-2xl border border-border-primary bg-background-secondary/20 p-4"
+    >
+      <header className="mb-3 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <h2 className="text-sm font-semibold text-text-primary">Live Activity</h2>
+          <ConnectionStatusBadge status={status} />
+        </div>
+        {events.length > 0 ? (
+          <button
+            type="button"
+            onClick={clear}
+            className="rounded-lg border border-border-primary bg-background-secondary/30 px-2.5 py-1 text-xs text-text-secondary transition hover:bg-background-secondary/60 focus:border-axion-500 focus:outline-none"
+          >
+            Clear
+          </button>
+        ) : null}
+      </header>
+
+      {visible.length === 0 ? (
+        <p className="py-8 text-center text-sm text-text-secondary">
+          {status === "error"
+            ? "Couldn't connect to the event stream. Retrying…"
+            : "Waiting for protocol activity…"}
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {visible.map((event) => (
+            <ActivityItem key={event.id} event={event} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/components/activity/ActivityItem.tsx
+++ b/src/components/activity/ActivityItem.tsx
@@ -1,0 +1,75 @@
+import { shortenAddress } from "@/utils/contractHelpers";
+import type { ActivityEvent, ActivityType } from "@/services/events/types";
+
+const TYPE_META: Record<ActivityType, { label: string; icon: string; className: string }> = {
+  deposit: {
+    label: "Deposit",
+    icon: "↓",
+    className: "border-emerald-900/50 bg-emerald-950/30 text-emerald-200",
+  },
+  withdrawal: {
+    label: "Withdrawal",
+    icon: "↑",
+    className: "border-sky-900/50 bg-sky-950/30 text-sky-200",
+  },
+  reward: {
+    label: "Reward",
+    icon: "★",
+    className: "border-amber-900/50 bg-amber-950/30 text-amber-200",
+  },
+  governance: {
+    label: "Governance",
+    icon: "⚖",
+    className: "border-violet-900/50 bg-violet-950/30 text-violet-200",
+  },
+  unknown: {
+    label: "Event",
+    icon: "•",
+    className: "border-border-primary bg-background-secondary/30 text-text-secondary",
+  },
+};
+
+function formatTimestamp(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return timestamp;
+  return date.toLocaleString();
+}
+
+export default function ActivityItem({ event }: { event: ActivityEvent }) {
+  const meta = TYPE_META[event.type] ?? TYPE_META.unknown;
+
+  return (
+    <li className="flex items-start gap-3 rounded-lg border border-border-primary bg-background-secondary/20 p-3">
+      <span
+        className={`mt-0.5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-sm ${meta.className}`}
+        aria-hidden="true"
+      >
+        {meta.icon}
+      </span>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center justify-between gap-2">
+          <span className="truncate text-sm font-medium text-text-primary">
+            {meta.label}
+            {event.name && event.name !== "unknown" ? (
+              <span className="ml-1 font-normal text-text-secondary">({event.name})</span>
+            ) : null}
+          </span>
+          <time
+            className="shrink-0 text-xs text-text-secondary"
+            dateTime={event.timestamp}
+          >
+            {formatTimestamp(event.timestamp)}
+          </time>
+        </div>
+
+        <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-text-secondary">
+          <span>Ledger #{event.ledger}</span>
+          {event.contractId && event.contractId !== "unknown" ? (
+            <span className="font-mono">{shortenAddress(event.contractId)}</span>
+          ) : null}
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/src/components/activity/ConnectionStatusBadge.tsx
+++ b/src/components/activity/ConnectionStatusBadge.tsx
@@ -1,0 +1,56 @@
+import type { ConnectionStatus } from "@/services/events/types";
+
+const STATUS_META: Record<
+  ConnectionStatus,
+  { label: string; dot: string; className: string }
+> = {
+  idle: {
+    label: "Idle",
+    dot: "bg-text-secondary",
+    className: "border-border-primary bg-background-secondary/30 text-text-secondary",
+  },
+  connecting: {
+    label: "Connecting",
+    dot: "bg-amber-400 animate-pulse",
+    className: "border-amber-900/50 bg-amber-950/30 text-amber-200",
+  },
+  connected: {
+    label: "Live",
+    dot: "bg-emerald-400",
+    className: "border-emerald-900/50 bg-emerald-950/30 text-emerald-200",
+  },
+  reconnecting: {
+    label: "Reconnecting",
+    dot: "bg-amber-400 animate-pulse",
+    className: "border-amber-900/50 bg-amber-950/30 text-amber-200",
+  },
+  disconnected: {
+    label: "Disconnected",
+    dot: "bg-text-secondary",
+    className: "border-border-primary bg-background-secondary/30 text-text-secondary",
+  },
+  error: {
+    label: "Connection error",
+    dot: "bg-rose-400",
+    className: "border-rose-900/50 bg-rose-950/30 text-rose-200",
+  },
+};
+
+export default function ConnectionStatusBadge({
+  status,
+}: {
+  status: ConnectionStatus;
+}) {
+  const meta = STATUS_META[status] ?? STATUS_META.idle;
+
+  return (
+    <span
+      role="status"
+      aria-live="polite"
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium ${meta.className}`}
+    >
+      <span className={`h-2 w-2 rounded-full ${meta.dot}`} aria-hidden="true" />
+      {meta.label}
+    </span>
+  );
+}

--- a/src/hooks/useActivityFeed.ts
+++ b/src/hooks/useActivityFeed.ts
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import { activityStore } from '@/store/activityStore';
+import {
+  getEventSubscriptionService,
+  type EventSubscriptionService,
+} from '@/services/events';
+
+export interface UseActivityFeedOptions {
+  /** Start streaming on mount (default true). */
+  enabled?: boolean;
+  /** Inject a service instance (tests / storybook). Defaults to the singleton. */
+  service?: EventSubscriptionService;
+}
+
+// Module-level bridge + refcount so the shared service is connected to the
+// shared store exactly once, regardless of how many components use the hook,
+// and is stopped only when the last consumer unmounts.
+let consumers = 0;
+let unbind: (() => void) | null = null;
+
+function startBridge(service: EventSubscriptionService): void {
+  if (unbind) return;
+  const offEvent = service.onEvent((event) => activityStore.addEvent(event));
+  const offStatus = service.onStatusChange((status) => activityStore.setStatus(status));
+  service.start();
+  unbind = () => {
+    offEvent();
+    offStatus();
+    service.stop();
+  };
+}
+
+function stopBridge(): void {
+  unbind?.();
+  unbind = null;
+}
+
+/**
+ * Subscribes the dashboard to the real-time protocol event stream and exposes
+ * the deduplicated activity feed plus connection status. Reads state via
+ * `useSyncExternalStore` so any consumer re-renders when new events arrive.
+ */
+export function useActivityFeed(options: UseActivityFeedOptions = {}) {
+  const { enabled = true, service } = options;
+
+  const snapshot = useSyncExternalStore(
+    activityStore.subscribe,
+    activityStore.getSnapshot,
+    activityStore.getSnapshot,
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+    const svc = service ?? getEventSubscriptionService();
+    consumers += 1;
+    startBridge(svc);
+
+    return () => {
+      consumers -= 1;
+      if (consumers <= 0) {
+        consumers = 0;
+        stopBridge();
+      }
+    };
+  }, [enabled, service]);
+
+  const clear = useCallback(() => activityStore.clear(), []);
+
+  return {
+    events: snapshot.events,
+    status: snapshot.status,
+    isConnected: snapshot.status === 'connected',
+    lastUpdated: snapshot.lastUpdated,
+    clear,
+  };
+}

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -7,6 +7,7 @@ import Navbar from "@/components/Navbar";
 import Sidebar from "@/components/Sidebar";
 import TransactionHistory from "@/components/TransactionHistory";
 import WithdrawForm from "@/components/WithdrawForm";
+import ActivityFeed from "@/components/activity/ActivityFeed";
 import { useEffect } from "react";
 import { useVaultContext } from "@/contexts/VaultContext";
 import { useWalletContext } from "@/hooks/useWallet";
@@ -103,6 +104,9 @@ export default function DashboardPage() {
                     onClaimRewards={vault.claimRewards}
                     isClaiming={vault.isClaiming}
                   />
+                </div>
+                <div className="mt-6 w-full">
+                  <ActivityFeed />
                 </div>
               </div>
             </div>

--- a/src/services/events/eventMapper.test.ts
+++ b/src/services/events/eventMapper.test.ts
@@ -1,0 +1,75 @@
+import { classifyActivity, mapRawEvents, toActivityEvent } from './eventMapper';
+import type { ParsedSorobanEvent } from '@/utils/parseEvents';
+
+describe('classifyActivity', () => {
+  it.each([
+    ['deposit', 'deposit'],
+    ['Deposit', 'deposit'],
+    ['stake', 'deposit'],
+    ['withdraw', 'withdrawal'],
+    ['redeem', 'withdrawal'],
+    ['unstake', 'withdrawal'],
+    ['reward', 'reward'],
+    ['claim_reward', 'reward'],
+    ['proposal_created', 'governance'],
+    ['vote', 'governance'],
+    ['something_else', 'unknown'],
+    ['', 'unknown'],
+  ])('classifies "%s" as %s', (name, expected) => {
+    expect(classifyActivity(name)).toBe(expected);
+  });
+});
+
+describe('toActivityEvent', () => {
+  it('maps a parsed event into a UI-ready activity event', () => {
+    const parsed: ParsedSorobanEvent = {
+      id: 'evt-1',
+      type: 'withdraw',
+      contractId: 'CCONTRACT',
+      ledger: 42,
+      ledgerClosedAt: '2026-01-01T00:00:00Z',
+      topics: ['withdraw', 'GUSER'],
+      value: '100',
+    };
+
+    expect(toActivityEvent(parsed)).toEqual({
+      id: 'evt-1',
+      type: 'withdrawal',
+      name: 'withdraw',
+      contractId: 'CCONTRACT',
+      ledger: 42,
+      timestamp: '2026-01-01T00:00:00Z',
+      topics: ['withdraw', 'GUSER'],
+      value: '100',
+    });
+  });
+});
+
+describe('mapRawEvents', () => {
+  it('parses and maps raw events end-to-end', () => {
+    const raw = [
+      {
+        id: 'e1',
+        topic: ['deposit'],
+        contractId: 'CVAULT',
+        ledger: 10,
+        ledgerClosedAt: '2026-01-01T00:00:00Z',
+        value: '5',
+      },
+    ];
+
+    const mapped = mapRawEvents(raw);
+    expect(mapped).toHaveLength(1);
+    expect(mapped[0]).toMatchObject({
+      id: 'e1',
+      type: 'deposit',
+      name: 'deposit',
+      contractId: 'CVAULT',
+      ledger: 10,
+    });
+  });
+
+  it('returns an empty array for non-array input', () => {
+    expect(mapRawEvents(undefined as never)).toEqual([]);
+  });
+});

--- a/src/services/events/eventMapper.ts
+++ b/src/services/events/eventMapper.ts
@@ -1,0 +1,62 @@
+import { parseSorobanEvents, type ParsedSorobanEvent } from '@/utils/parseEvents';
+import type { ActivityEvent, ActivityType, RawSorobanEvent } from './types';
+
+/**
+ * Maps a raw event name (first topic) to a high-level activity category.
+ * Matching is case-insensitive and tolerant of common naming variants so the
+ * feed stays meaningful across slightly different contract event names.
+ */
+export function classifyActivity(name: string): ActivityType {
+  const n = (name ?? '').toLowerCase();
+
+  // Check withdrawal first: "unstake" contains "stake", so it must win over the
+  // deposit heuristic below.
+  if (
+    n.includes('withdraw') ||
+    n.includes('redeem') ||
+    n.includes('burn') ||
+    n.includes('unstake')
+  ) {
+    return 'withdrawal';
+  }
+  if (n.includes('deposit') || n.includes('mint') || n.includes('stake')) {
+    return 'deposit';
+  }
+  if (n.includes('reward') || n.includes('claim') || n.includes('yield')) {
+    return 'reward';
+  }
+  if (
+    n.includes('proposal') ||
+    n.includes('vote') ||
+    n.includes('govern') ||
+    n.includes('execute')
+  ) {
+    return 'governance';
+  }
+  return 'unknown';
+}
+
+/**
+ * Converts a parsed Soroban event into a UI-ready {@link ActivityEvent}.
+ */
+export function toActivityEvent(parsed: ParsedSorobanEvent): ActivityEvent {
+  return {
+    id: parsed.id,
+    type: classifyActivity(parsed.type),
+    name: parsed.type,
+    contractId: parsed.contractId,
+    ledger: parsed.ledger,
+    timestamp: parsed.ledgerClosedAt,
+    topics: parsed.topics,
+    value: parsed.value,
+  };
+}
+
+/**
+ * Parses and maps a batch of raw events into activity events, reusing the
+ * shared {@link parseSorobanEvents} decoder for consistency with the rest of
+ * the app.
+ */
+export function mapRawEvents(rawEvents: RawSorobanEvent[]): ActivityEvent[] {
+  return parseSorobanEvents(rawEvents).map(toActivityEvent);
+}

--- a/src/services/events/eventSubscriptionService.test.ts
+++ b/src/services/events/eventSubscriptionService.test.ts
@@ -1,0 +1,163 @@
+import { EventSubscriptionService } from './eventSubscriptionService';
+import type { ActivityEvent, EventFetcher, RawSorobanEvent } from './types';
+
+function makeRaw(id: string, name = 'deposit', ledger = 100): RawSorobanEvent {
+  return {
+    id,
+    topic: [name],
+    contractId: 'CVAULT',
+    ledger,
+    ledgerClosedAt: '2026-01-01T00:00:00Z',
+    value: '1',
+  };
+}
+
+function makeService(
+  fetcher: EventFetcher,
+  overrides: Partial<ConstructorParameters<typeof EventSubscriptionService>[0]> = {},
+) {
+  const service = new EventSubscriptionService({
+    contractIds: ['CVAULT'],
+    fetcher,
+    pollIntervalMs: 5000,
+    baseReconnectDelayMs: 1000,
+    maxReconnectDelayMs: 30000,
+    maxReconnectAttempts: 3,
+    ...overrides,
+  });
+  const events: ActivityEvent[] = [];
+  const statuses: string[] = [];
+  service.onEvent((e) => events.push(e));
+  service.onStatusChange((s) => statuses.push(s));
+  return { service, events, statuses };
+}
+
+describe('EventSubscriptionService', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('connects and emits events from the latest ledger', async () => {
+    const fetcher: EventFetcher = {
+      getLatestLedger: jest.fn().mockResolvedValue(100),
+      getEvents: jest.fn().mockResolvedValue({ events: [makeRaw('e1')], latestLedger: 100 }),
+    };
+    const { service, events, statuses } = makeService(fetcher);
+
+    service.start();
+    await jest.advanceTimersByTimeAsync(0);
+
+    expect(statuses).toContain('connecting');
+    expect(statuses).toContain('connected');
+    expect(events.map((e) => e.id)).toEqual(['e1']);
+    expect(service.getStatus()).toBe('connected');
+
+    service.stop();
+  });
+
+  it('deduplicates events redelivered across polls', async () => {
+    const fetcher: EventFetcher = {
+      getLatestLedger: jest.fn().mockResolvedValue(100),
+      getEvents: jest
+        .fn()
+        // Same id 'e1' returned twice; 'e2' is new on the second poll.
+        .mockResolvedValueOnce({ events: [makeRaw('e1')], latestLedger: 100 })
+        .mockResolvedValueOnce({ events: [makeRaw('e1'), makeRaw('e2')], latestLedger: 101 }),
+    };
+    const { service, events } = makeService(fetcher);
+
+    service.start();
+    await jest.advanceTimersByTimeAsync(0); // first poll
+    await jest.advanceTimersByTimeAsync(5000); // second poll after interval
+
+    expect(events.map((e) => e.id)).toEqual(['e1', 'e2']);
+
+    service.stop();
+  });
+
+  it('advances the ledger cursor between polls', async () => {
+    const getEvents = jest
+      .fn()
+      .mockResolvedValueOnce({ events: [], latestLedger: 100 })
+      .mockResolvedValueOnce({ events: [], latestLedger: 105 });
+    const fetcher: EventFetcher = {
+      getLatestLedger: jest.fn().mockResolvedValue(100),
+      getEvents,
+    };
+    const { service } = makeService(fetcher);
+
+    service.start();
+    await jest.advanceTimersByTimeAsync(0);
+    await jest.advanceTimersByTimeAsync(5000);
+
+    // First call starts at the latest ledger (100); second resumes at 101.
+    expect(getEvents.mock.calls[0][0].startLedger).toBe(100);
+    expect(getEvents.mock.calls[1][0].startLedger).toBe(101);
+
+    service.stop();
+  });
+
+  it('reconnects with backoff after a transient failure', async () => {
+    const getEvents = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValue({ events: [makeRaw('e1')], latestLedger: 100 });
+    const fetcher: EventFetcher = {
+      getLatestLedger: jest.fn().mockResolvedValue(100),
+      getEvents,
+    };
+    const { service, events, statuses } = makeService(fetcher);
+
+    service.start();
+    await jest.advanceTimersByTimeAsync(0); // first poll fails
+
+    expect(statuses).toContain('reconnecting');
+    expect(service.getStatus()).toBe('reconnecting');
+
+    // Backoff = base * 2^0 = 1000ms for the first retry.
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(events.map((e) => e.id)).toEqual(['e1']);
+    expect(service.getStatus()).toBe('connected');
+
+    service.stop();
+  });
+
+  it('gives up with error status after exhausting reconnect attempts', async () => {
+    const fetcher: EventFetcher = {
+      getLatestLedger: jest.fn().mockResolvedValue(100),
+      getEvents: jest.fn().mockRejectedValue(new Error('always down')),
+    };
+    const { service, statuses } = makeService(fetcher, { maxReconnectAttempts: 2 });
+
+    service.start();
+    await jest.advanceTimersByTimeAsync(0); // attempt 1 -> reconnecting
+    await jest.advanceTimersByTimeAsync(1000); // attempt 2 -> reconnecting
+    await jest.advanceTimersByTimeAsync(2000); // attempt 3 -> exceeds max -> error
+
+    expect(service.getStatus()).toBe('error');
+    expect(statuses[statuses.length - 1]).toBe('error');
+  });
+
+  it('stops polling after stop()', async () => {
+    const getEvents = jest
+      .fn()
+      .mockResolvedValue({ events: [], latestLedger: 100 });
+    const fetcher: EventFetcher = {
+      getLatestLedger: jest.fn().mockResolvedValue(100),
+      getEvents,
+    };
+    const { service } = makeService(fetcher);
+
+    service.start();
+    await jest.advanceTimersByTimeAsync(0);
+    const callsAfterFirst = getEvents.mock.calls.length;
+
+    service.stop();
+    await jest.advanceTimersByTimeAsync(20000);
+
+    expect(getEvents.mock.calls.length).toBe(callsAfterFirst);
+    expect(service.getStatus()).toBe('disconnected');
+  });
+});

--- a/src/services/events/eventSubscriptionService.ts
+++ b/src/services/events/eventSubscriptionService.ts
@@ -1,0 +1,206 @@
+import { mapRawEvents } from './eventMapper';
+import type {
+  ActivityEvent,
+  ConnectionStatus,
+  EventFetcher,
+  EventListener,
+  StatusListener,
+} from './types';
+
+export interface EventSubscriptionOptions {
+  /** Contract ids to stream events for. */
+  contractIds: string[];
+  /** Data source. Injectable for testing; defaults to a Soroban RPC poller. */
+  fetcher: EventFetcher;
+  /** Delay between successful polls. */
+  pollIntervalMs?: number;
+  /** Max consecutive failures before giving up and surfacing `error`. */
+  maxReconnectAttempts?: number;
+  /** Base delay for exponential backoff. */
+  baseReconnectDelayMs?: number;
+  /** Upper bound for a single backoff delay. */
+  maxReconnectDelayMs?: number;
+  /** Page size requested from the fetcher. */
+  pageLimit?: number;
+  /** Cap on the dedupe id cache to bound memory. */
+  dedupeCacheSize?: number;
+}
+
+const DEFAULTS = {
+  pollIntervalMs: 5000,
+  maxReconnectAttempts: 10,
+  baseReconnectDelayMs: 1000,
+  maxReconnectDelayMs: 30000,
+  pageLimit: 100,
+  dedupeCacheSize: 1000,
+};
+
+type ResolvedOptions = Required<EventSubscriptionOptions>;
+
+/**
+ * Streams protocol events in real time by polling a {@link EventFetcher}
+ * (Soroban RPC `getEvents` by default) and emitting normalized
+ * {@link ActivityEvent}s.
+ *
+ * Responsibilities (issue #215):
+ * - **Subscription** — `onEvent` / `onStatusChange` with unsubscribe handles.
+ * - **Reconnection** — consecutive failures retry with capped exponential
+ *   backoff; the ledger cursor is preserved so no events are missed across a
+ *   reconnect, and the service surfaces `reconnecting` then `error` if it
+ *   exhausts `maxReconnectAttempts`.
+ * - **Deduplication** — events already emitted (by id) are dropped, with a
+ *   bounded cache so long-lived streams don't grow unbounded.
+ */
+export class EventSubscriptionService {
+  private readonly opts: ResolvedOptions;
+  private readonly listeners = new Set<EventListener>();
+  private readonly statusListeners = new Set<StatusListener>();
+  private readonly seenIds = new Set<string>();
+
+  private status: ConnectionStatus = 'idle';
+  private cursor: number | null = null;
+  private reconnectAttempts = 0;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private running = false;
+
+  constructor(options: EventSubscriptionOptions) {
+    this.opts = { ...DEFAULTS, ...options };
+  }
+
+  getStatus(): ConnectionStatus {
+    return this.status;
+  }
+
+  /** Subscribe to normalized events. Returns an unsubscribe function. */
+  onEvent(listener: EventListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  /** Subscribe to connection-status changes. Returns an unsubscribe function. */
+  onStatusChange(listener: StatusListener): () => void {
+    this.statusListeners.add(listener);
+    return () => this.statusListeners.delete(listener);
+  }
+
+  /** Begin streaming. Idempotent. */
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    this.reconnectAttempts = 0;
+    this.setStatus('connecting');
+    this.schedule(0);
+  }
+
+  /** Stop streaming and clear any pending timer. */
+  stop(): void {
+    if (!this.running && this.status === 'disconnected') return;
+    this.running = false;
+    this.clearTimer();
+    this.setStatus('disconnected');
+  }
+
+  private clearTimer(): void {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private schedule(delayMs: number): void {
+    if (!this.running) return;
+    this.clearTimer();
+    this.timer = setTimeout(() => {
+      void this.tick();
+    }, delayMs);
+  }
+
+  private async tick(): Promise<void> {
+    if (!this.running) return;
+    try {
+      // Establish the start cursor from the current ledger on first run (or
+      // after a bootstrap failure) so we stream from "now" forward.
+      if (this.cursor === null) {
+        this.cursor = await this.opts.fetcher.getLatestLedger();
+      }
+
+      const { events, latestLedger } = await this.opts.fetcher.getEvents({
+        startLedger: this.cursor,
+        contractIds: this.opts.contractIds,
+        limit: this.opts.pageLimit,
+      });
+
+      this.emitNew(events);
+
+      // Advance the cursor past the latest processed ledger.
+      if (typeof latestLedger === 'number' && latestLedger >= this.cursor) {
+        this.cursor = latestLedger + 1;
+      }
+
+      if (!this.running) return;
+      this.reconnectAttempts = 0;
+      this.setStatus('connected');
+      this.schedule(this.opts.pollIntervalMs);
+    } catch {
+      this.handleFailure();
+    }
+  }
+
+  private handleFailure(): void {
+    if (!this.running) return;
+    this.reconnectAttempts += 1;
+
+    if (this.reconnectAttempts > this.opts.maxReconnectAttempts) {
+      // Give up; consumer can call start() again to retry from scratch.
+      this.running = false;
+      this.clearTimer();
+      this.setStatus('error');
+      return;
+    }
+
+    this.setStatus('reconnecting');
+    this.schedule(this.backoffDelay());
+  }
+
+  /** Capped exponential backoff for the current attempt. */
+  private backoffDelay(): number {
+    const exp = this.opts.baseReconnectDelayMs * 2 ** (this.reconnectAttempts - 1);
+    return Math.min(exp, this.opts.maxReconnectDelayMs);
+  }
+
+  private emitNew(rawEvents: unknown[]): void {
+    const events = mapRawEvents(rawEvents as Record<string, unknown>[]);
+    for (const event of events) {
+      if (this.seenIds.has(event.id)) continue;
+      this.rememberId(event.id);
+      this.listeners.forEach((cb) => cb(event));
+    }
+  }
+
+  private rememberId(id: string): void {
+    this.seenIds.add(id);
+    if (this.seenIds.size > this.opts.dedupeCacheSize) {
+      // Evict the oldest half to keep the cache bounded.
+      const drop = Math.floor(this.opts.dedupeCacheSize / 2);
+      let i = 0;
+      for (const old of this.seenIds) {
+        if (i++ >= drop) break;
+        this.seenIds.delete(old);
+      }
+    }
+  }
+
+  private setStatus(status: ConnectionStatus): void {
+    if (this.status === status) return;
+    this.status = status;
+    this.statusListeners.forEach((cb) => cb(status));
+  }
+}
+
+export function createEventSubscriptionService(
+  options: EventSubscriptionOptions,
+): EventSubscriptionService {
+  return new EventSubscriptionService(options);
+}
+
+export type { ActivityEvent };

--- a/src/services/events/index.ts
+++ b/src/services/events/index.ts
@@ -1,0 +1,41 @@
+import {
+  AXIONVERA_TOKEN_CONTRACT_ID,
+  AXIONVERA_VAULT_CONTRACT_ID,
+} from '@/utils/networkConfig';
+import {
+  EventSubscriptionService,
+  createEventSubscriptionService,
+} from './eventSubscriptionService';
+import { createSorobanRpcFetcher } from './sorobanRpcFetcher';
+
+export * from './types';
+export * from './eventMapper';
+export {
+  EventSubscriptionService,
+  createEventSubscriptionService,
+} from './eventSubscriptionService';
+export type { EventSubscriptionOptions } from './eventSubscriptionService';
+export { createSorobanRpcFetcher } from './sorobanRpcFetcher';
+
+/** Contract ids whose events appear in the dashboard activity feed. */
+export const DEFAULT_EVENT_CONTRACT_IDS = [
+  AXIONVERA_VAULT_CONTRACT_ID,
+  AXIONVERA_TOKEN_CONTRACT_ID,
+].filter((id) => Boolean(id) && !id.startsWith('REPLACE_WITH'));
+
+let singleton: EventSubscriptionService | null = null;
+
+/**
+ * Lazily-created shared subscription service wired to the Soroban RPC fetcher
+ * and the default protocol contracts. Hooks/components reuse this so the app
+ * keeps a single stream regardless of how many consumers subscribe.
+ */
+export function getEventSubscriptionService(): EventSubscriptionService {
+  if (!singleton) {
+    singleton = createEventSubscriptionService({
+      contractIds: DEFAULT_EVENT_CONTRACT_IDS,
+      fetcher: createSorobanRpcFetcher(),
+    });
+  }
+  return singleton;
+}

--- a/src/services/events/sorobanRpcFetcher.ts
+++ b/src/services/events/sorobanRpcFetcher.ts
@@ -1,0 +1,62 @@
+import { SOROBAN_RPC_URL } from '@/utils/networkConfig';
+import type { EventFetcher, RawSorobanEvent } from './types';
+
+/**
+ * JSON-RPC helper for the Soroban RPC server.
+ */
+async function rpcCall<T>(rpcUrl: string, method: string, params: unknown): Promise<T> {
+  const res = await fetch(rpcUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Soroban RPC ${method} failed: HTTP ${res.status}`);
+  }
+
+  const body = (await res.json()) as { result?: T; error?: { message?: string } };
+  if (body.error) {
+    throw new Error(`Soroban RPC ${method} error: ${body.error.message ?? 'unknown'}`);
+  }
+  if (body.result === undefined) {
+    throw new Error(`Soroban RPC ${method} returned no result`);
+  }
+  return body.result;
+}
+
+/**
+ * Builds an {@link EventFetcher} backed by the Soroban RPC `getEvents` and
+ * `getLatestLedger` methods. This is the default real-time data source; there
+ * is no public Soroban event websocket, so the streaming layer polls forward
+ * from the latest ledger (backend indexing is intentionally out of scope).
+ */
+export function createSorobanRpcFetcher(rpcUrl: string = SOROBAN_RPC_URL): EventFetcher {
+  return {
+    async getLatestLedger(): Promise<number> {
+      const result = await rpcCall<{ sequence: number }>(rpcUrl, 'getLatestLedger', {});
+      return Number(result.sequence);
+    },
+
+    async getEvents({ startLedger, contractIds, limit }) {
+      const result = await rpcCall<{
+        events?: RawSorobanEvent[];
+        latestLedger: number;
+      }>(rpcUrl, 'getEvents', {
+        startLedger,
+        filters: [
+          {
+            type: 'contract',
+            contractIds: contractIds.filter(Boolean),
+          },
+        ],
+        pagination: { limit },
+      });
+
+      return {
+        events: result.events ?? [],
+        latestLedger: Number(result.latestLedger),
+      };
+    },
+  };
+}

--- a/src/services/events/types.ts
+++ b/src/services/events/types.ts
@@ -1,0 +1,67 @@
+import type { ParsedSorobanEvent } from '@/utils/parseEvents';
+
+/**
+ * High-level category a protocol event maps to for the activity feed.
+ */
+export type ActivityType =
+  | 'deposit'
+  | 'withdrawal'
+  | 'reward'
+  | 'governance'
+  | 'unknown';
+
+/**
+ * Connection state of the real-time event subscription.
+ */
+export type ConnectionStatus =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'disconnected'
+  | 'error';
+
+/**
+ * A normalized, UI-ready protocol event derived from a raw Soroban event.
+ */
+export interface ActivityEvent {
+  /** Stable unique id (used for deduplication and React keys). */
+  id: string;
+  /** Category used to render and group the event. */
+  type: ActivityType;
+  /** Raw event name (first topic), e.g. "deposit", "withdraw", "vote". */
+  name: string;
+  /** Contract that emitted the event. */
+  contractId: string;
+  /** Ledger sequence the event was included in. */
+  ledger: number;
+  /** ISO timestamp the ledger closed (best-effort). */
+  timestamp: string;
+  /** Decoded event topics. */
+  topics: string[];
+  /** Decoded event value payload. */
+  value: unknown;
+}
+
+/** Raw event shape as returned by Soroban RPC `getEvents` / Horizon. */
+export type RawSorobanEvent = Record<string, unknown>;
+
+/**
+ * Fetches protocol events from a data source (Soroban RPC by default).
+ * Injectable so the subscription service can be unit-tested without a network.
+ */
+export interface EventFetcher {
+  /** Returns the latest ledger sequence, used as the streaming start cursor. */
+  getLatestLedger(): Promise<number>;
+  /** Returns events at/after `startLedger` for the given contracts. */
+  getEvents(params: {
+    startLedger: number;
+    contractIds: string[];
+    limit: number;
+  }): Promise<{ events: RawSorobanEvent[]; latestLedger: number }>;
+}
+
+export type EventListener = (event: ActivityEvent) => void;
+export type StatusListener = (status: ConnectionStatus) => void;
+
+export type { ParsedSorobanEvent };

--- a/src/store/activityStore.test.ts
+++ b/src/store/activityStore.test.ts
@@ -1,0 +1,88 @@
+import { ActivityStore } from './activityStore';
+import type { ActivityEvent } from '@/services/events/types';
+
+function makeEvent(id: string, overrides: Partial<ActivityEvent> = {}): ActivityEvent {
+  return {
+    id,
+    type: 'deposit',
+    name: 'deposit',
+    contractId: 'CVAULT',
+    ledger: 1,
+    timestamp: '2026-01-01T00:00:00Z',
+    topics: ['deposit'],
+    value: '1',
+    ...overrides,
+  };
+}
+
+describe('ActivityStore', () => {
+  it('starts empty and idle', () => {
+    const store = new ActivityStore();
+    const snap = store.getSnapshot();
+    expect(snap.events).toEqual([]);
+    expect(snap.status).toBe('idle');
+    expect(snap.lastUpdated).toBeNull();
+  });
+
+  it('adds events newest-first', () => {
+    const store = new ActivityStore();
+    store.addEvent(makeEvent('a'));
+    store.addEvent(makeEvent('b'));
+    expect(store.getSnapshot().events.map((e) => e.id)).toEqual(['b', 'a']);
+  });
+
+  it('ignores duplicate events by id', () => {
+    const store = new ActivityStore();
+    store.addEvent(makeEvent('a'));
+    store.addEvent(makeEvent('a'));
+    store.addEvents([makeEvent('a'), makeEvent('b')]);
+    expect(store.getSnapshot().events.map((e) => e.id)).toEqual(['b', 'a']);
+  });
+
+  it('caps the feed at maxEvents', () => {
+    const store = new ActivityStore(3);
+    store.addEvents([
+      makeEvent('a'),
+      makeEvent('b'),
+      makeEvent('c'),
+      makeEvent('d'),
+    ]);
+    const ids = store.getSnapshot().events.map((e) => e.id);
+    expect(ids).toHaveLength(3);
+    expect(ids[0]).toBe('d'); // newest retained
+  });
+
+  it('updates status and notifies subscribers', () => {
+    const store = new ActivityStore();
+    const listener = jest.fn();
+    const unsubscribe = store.subscribe(listener);
+
+    store.setStatus('connected');
+    expect(store.getSnapshot().status).toBe('connected');
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    // No-op when status is unchanged.
+    store.setStatus('connected');
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    store.setStatus('disconnected');
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not notify when only duplicates are added', () => {
+    const store = new ActivityStore();
+    store.addEvent(makeEvent('a'));
+    const listener = jest.fn();
+    store.subscribe(listener);
+    store.addEvent(makeEvent('a'));
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('clears the feed', () => {
+    const store = new ActivityStore();
+    store.addEvents([makeEvent('a'), makeEvent('b')]);
+    store.clear();
+    expect(store.getSnapshot().events).toEqual([]);
+  });
+});

--- a/src/store/activityStore.ts
+++ b/src/store/activityStore.ts
@@ -1,0 +1,92 @@
+import type { ActivityEvent, ConnectionStatus } from '@/services/events/types';
+
+export interface ActivityState {
+  /** Most-recent-first list of activity events. */
+  events: ActivityEvent[];
+  /** Current stream connection status. */
+  status: ConnectionStatus;
+  /** Epoch ms of the last state change (null until first update). */
+  lastUpdated: number | null;
+}
+
+/** Max events retained in the feed to bound memory/DOM size. */
+const DEFAULT_MAX_EVENTS = 200;
+
+/**
+ * Minimal framework-agnostic observable store for dashboard activity.
+ *
+ * Decoupled from React (consumed via `useSyncExternalStore` in
+ * {@link useActivityFeed}) so it is trivially unit-testable and can be driven
+ * by the event subscription service. Adding events is idempotent: duplicates
+ * (by id) are ignored, mirroring the service-level dedupe so the UI never shows
+ * the same event twice even if a reconnect re-delivers it.
+ */
+export class ActivityStore {
+  private state: ActivityState = {
+    events: [],
+    status: 'idle',
+    lastUpdated: null,
+  };
+
+  private readonly listeners = new Set<() => void>();
+  private readonly seenIds = new Set<string>();
+  private readonly maxEvents: number;
+
+  constructor(maxEvents: number = DEFAULT_MAX_EVENTS) {
+    this.maxEvents = maxEvents;
+    // Pre-bind so `useSyncExternalStore` gets a stable subscribe reference.
+    this.subscribe = this.subscribe.bind(this);
+    this.getSnapshot = this.getSnapshot.bind(this);
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  getSnapshot(): ActivityState {
+    return this.state;
+  }
+
+  /** Add one event (newest first), ignoring duplicates by id. */
+  addEvent(event: ActivityEvent): void {
+    this.addEvents([event]);
+  }
+
+  /** Add a batch of events, ignoring duplicates and capping the list size. */
+  addEvents(incoming: ActivityEvent[]): void {
+    const fresh = incoming.filter((e) => !this.seenIds.has(e.id));
+    if (fresh.length === 0) return;
+
+    fresh.forEach((e) => this.seenIds.add(e.id));
+    const merged = [...fresh.reverse(), ...this.state.events].slice(0, this.maxEvents);
+
+    // Keep the dedupe set aligned with what's actually retained.
+    if (this.seenIds.size > this.maxEvents * 2) {
+      this.seenIds.clear();
+      merged.forEach((e) => this.seenIds.add(e.id));
+    }
+
+    this.state = { ...this.state, events: merged, lastUpdated: Date.now() };
+    this.emit();
+  }
+
+  setStatus(status: ConnectionStatus): void {
+    if (this.state.status === status) return;
+    this.state = { ...this.state, status, lastUpdated: Date.now() };
+    this.emit();
+  }
+
+  clear(): void {
+    this.seenIds.clear();
+    this.state = { ...this.state, events: [], lastUpdated: Date.now() };
+    this.emit();
+  }
+
+  private emit(): void {
+    this.listeners.forEach((cb) => cb());
+  }
+}
+
+/** Shared store instance used by the dashboard. */
+export const activityStore = new ActivityStore();


### PR DESCRIPTION
## Summary

**Closes #215.** Adds a real-time event streaming layer so deposits, withdrawals, rewards, and governance actions appear on the dashboard **live, without manual refresh**.

## Architecture decisions

Built in the issue's prescribed paths, complementing (not modifying) the existing `src/utils/sorobanEventStream.ts` stub:

- **`src/services/events/`** — the event subscription service.
  - **Data source:** there is no public Soroban event websocket, so the layer polls Soroban RPC **`getEvents`** forward from the latest ledger. The fetcher is an injectable interface (`EventFetcher`) with a default `createSorobanRpcFetcher`, which keeps the service unit-testable without a network and keeps **backend indexing out of scope**.
  - **`eventMapper.ts`** decodes raw events (reusing the shared `parseSorobanEvents`) and classifies them into `deposit | withdrawal | reward | governance | unknown`.
- **`src/store/activityStore.ts`** — a framework-agnostic observable store consumed via `useSyncExternalStore`. Dedupes/caps the feed and tracks connection status.
- **`src/hooks/useActivityFeed.ts`** — bridges the shared service into the store with **refcounting**, so there's a single stream regardless of how many components subscribe, and it's torn down when the last consumer unmounts.
- **`src/components/activity/`** — `ActivityFeed` + `ActivityItem` + a connection-status badge, wired into the dashboard page.

## Reconnection strategy

Consecutive fetch failures retry with **capped exponential backoff** (`base · 2^(n-1)`, capped at `maxReconnectDelayMs`). The ledger **cursor is preserved across reconnects** so no events are missed; status transitions `connecting → connected`, `reconnecting` on failure, and `error` once `maxReconnectAttempts` is exhausted (a consumer can `start()` again to retry).

## Deduplication

Both the service and the store drop events already seen (by id), each with a bounded cache, so a reconnect that re-delivers events never produces duplicates in the UI.

## ✅ Acceptance criteria

- ✅ **Events update UI in real time** — `ActivityFeed` (mounted on `/dashboard`) re-renders via `useSyncExternalStore` as events arrive.
- ✅ **Reconnection works automatically** — capped exponential backoff with cursor preservation.
- ✅ **Duplicate events are ignored** — id-based dedupe at service and store layers.
- ✅ **Tests cover event processing** — 28 jest tests across mapper, store, and service.

## Test coverage

```
src/services/events/eventMapper.test.ts            (classification + decode/map)
src/store/activityStore.test.ts                    (dedupe, order, cap, status, subscribe)
src/services/events/eventSubscriptionService.test.ts (connect/emit, dedupe across polls,
                                                     cursor advance, backoff reconnect,
                                                     give-up, stop)
→ 28 passing
```

New files typecheck and lint clean.

> **Note:** the repo's `lint`/`typecheck` CI is already red on `main` from unrelated pre-existing issues (e.g. missing `recharts` dependency, a duplicate `menuItems` in `Sidebar.tsx`, and `@testing-library/react` `screen`/`waitFor` import errors across existing test files). None of those files are touched here — the code added in this PR passes `tsc --noEmit` and `next lint` on its own, and its jest suite is green.