### PR TITLE
Add dashboard visualization framework

### DIFF
--- a/docs/VISUALIZATION_FRAMEWORK.md
+++ b/docs/VISUALIZATION_FRAMEWORK.md
@@ -1,0 +1,147 @@
+# Dashboard Visualization Framework
+
+This document describes the reusable visualization framework used to standardize
+charts, graphs, protocol metrics, and statistical visualizations across the
+Axionvera dashboard.
+
+## Goals
+
+- **Consistency**: Every chart uses the same theme-aware container, tooltip,
+  legend, and color tokens.
+- **Accessibility**: Charts expose ARIA roles/labels, respect reduced-motion
+  preferences, and provide loading/error/empty states.
+- **Responsiveness**: All charts render inside `ResponsiveContainer` and adapt
+  to their parent width.
+- **Performance**: Memoized transformations, stable gradient ids, and
+  deterministic color assignment reduce unnecessary re-renders.
+- **Maintainability**: New chart types can be built from shared primitives
+  without duplicating styling or accessibility logic.
+
+## Architecture
+
+```text
+src/visualizations/          Framework primitives and public API
+├── components/
+│   ├── ChartContainer.tsx   Responsive wrapper with states + a11y
+│   ├── ChartTooltip.tsx     Theme-aware tooltip
+│   ├── ChartLegend.tsx      Theme-aware legend formatter
+│   └── EmptyState.tsx       Consistent empty placeholder
+├── hooks/
+│   └── useChartTheme.ts     Resolves light/dark tokens from ThemeContext
+├── theme.ts                 Color palettes and token builders
+├── types.ts                 Shared TypeScript interfaces
+├── utils/
+│   └── colors.ts            Gradient ids, color scales, hex helpers
+└── index.ts                 Public API
+
+src/charts/                  Reusable low-level chart components
+├── BarChart.tsx
+├── LineChart.tsx
+├── PieChart.tsx
+├── ComposedChart.tsx
+├── HealthLatencyBars.tsx
+└── index.ts
+
+src/components/visualizations/  Domain-specific chart components
+├── APYChart.tsx
+├── FlowChart.tsx
+├── PerformanceChart.tsx
+└── index.ts
+```
+
+## Quick Start
+
+```tsx
+import { BarChart } from "@/charts";
+
+<BarChart
+  data={[
+    { label: "Jan", value: 120 },
+    { label: "Feb", value: 200 },
+  ]}
+  title="Monthly Volume"
+  accessibility={{ label: "Monthly volume bar chart" }}
+/>
+```
+
+## Theming
+
+The framework reads the active theme from `ThemeContext` and exposes tokens via
+`useChartTheme()`:
+
+```ts
+const theme = useChartTheme();
+// theme.background, theme.foreground, theme.grid, theme.series, ...
+```
+
+For SSR or Storybook, pass an explicit mode:
+
+```ts
+const theme = useChartTheme({ mode: "dark" });
+```
+
+Color palettes:
+
+- `DEFAULT_SERIES_COLORS` – default dashboard palette.
+- `COLORBLIND_SERIES_COLORS` – color-blind friendly alternative.
+
+## Accessibility
+
+- Every chart is wrapped in `role="img"` with an `aria-label`.
+- Provide `accessibility.label` and `accessibility.description` for screen
+  readers.
+- Set `accessibility.hidden` for decorative charts.
+- The container respects `prefers-reduced-motion` and disables entry
+  transitions when requested.
+- Loading, error, and empty states are announced via `role="status"` or
+  `role="alert"`.
+
+## Building a New Chart
+
+Use `ChartContainer` and the theme hooks to keep behavior consistent:
+
+```tsx
+import { ChartContainer, ChartTooltip, useChartTheme } from "@/visualizations";
+import { RadarChart, Radar, PolarGrid, PolarAngleAxis } from "recharts";
+
+export function MetricRadar({ data, title }) {
+  const theme = useChartTheme();
+  return (
+    <ChartContainer data={data} title={title} accessibility={{ label: title }}>
+      <RadarChart data={data}>
+        <PolarGrid stroke={theme.grid} />
+        <PolarAngleAxis dataKey="label" tick={{ fill: theme.muted }} />
+        <Radar dataKey="value" stroke={theme.series[0]} fill={theme.series[0]} />
+        <Tooltip content={<ChartTooltip />} />
+      </RadarChart>
+    </ChartContainer>
+  );
+}
+```
+
+## Performance Guidelines
+
+1. Memoize derived data with `useMemo`.
+2. Use `gradientId(key)` for stable SVG gradient identifiers.
+3. Use `resolveColor(index)` instead of inline random colors.
+4. Keep heavy formatting functions outside render closures or memoize them.
+
+## Testing
+
+Chart tests live in `tests/charts/` and `src/visualizations/__tests__/`. The
+Jest setup mocks `ResizeObserver` so Recharts `ResponsiveContainer` renders in
+jsdom.
+
+Run chart tests:
+
+```bash
+npm test -- --testPathPattern="visualizations|tests/charts"
+```
+
+## Out of Scope
+
+- Backend analytics pipelines.
+- AI-generated charts.
+- Full dashboard redesigns.
+
+These items should be tracked as separate issues.

--- a/src/charts/BarChart.tsx
+++ b/src/charts/BarChart.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import {
   BarChart as ReBarChart,
   Bar,
@@ -6,9 +6,10 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
-  ResponsiveContainer,
   Cell,
 } from "recharts";
+import { ChartContainer, ChartTooltip, useChartTheme, resolveColor } from "@/visualizations";
+import type { ChartAccessibility } from "@/visualizations";
 
 export interface BarChartDataPoint {
   label: string;
@@ -30,13 +31,15 @@ interface BarChartProps {
   className?: string;
   barSize?: number;
   radius?: [number, number, number, number];
+  title?: string;
+  accessibility?: ChartAccessibility;
 }
 
 export function BarChart({
   data,
   dataKey = "value",
   labelKey = "label",
-  color = "#6366f1",
+  color,
   colors,
   showGrid = true,
   showTooltip = true,
@@ -46,48 +49,68 @@ export function BarChart({
   className = "",
   barSize = 24,
   radius = [4, 4, 0, 0],
+  title,
+  accessibility,
 }: BarChartProps) {
+  const theme = useChartTheme();
+
+  const seriesColor = useMemo(
+    () => color || theme.series[0],
+    [color, theme.series]
+  );
+
   return (
-    <div className={`w-full ${className}`}>
-      <ResponsiveContainer width="100%" height={height}>
-        <ReBarChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
-          {showGrid && (
-            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
-          )}
-          <XAxis
-            dataKey={labelKey}
-            tick={{ fontSize: 12, fill: "rgba(255,255,255,0.5)" }}
-            axisLine={{ stroke: "rgba(255,255,255,0.1)" }}
-            tickLine={false}
-            minTickGap={30}
+    <ChartContainer
+      data={data}
+      title={title}
+      height={height}
+      className={className}
+      accessibility={accessibility}
+    >
+      <ReBarChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+        {showGrid && <CartesianGrid strokeDasharray="3 3" stroke={theme.grid} />}
+        <XAxis
+          dataKey={labelKey}
+          tick={{ fontSize: 12, fill: theme.muted }}
+          axisLine={{ stroke: theme.axis }}
+          tickLine={false}
+          minTickGap={30}
+        />
+        <YAxis
+          tick={{ fontSize: 12, fill: theme.muted }}
+          axisLine={false}
+          tickLine={false}
+          tickFormatter={yAxisFormatter}
+          width={60}
+        />
+        {showTooltip && (
+          <Tooltip
+            content={
+              <ChartTooltip
+                formatter={(value) =>
+                  tooltipFormatter(Number(value))
+                }
+              />
+            }
           />
-          <YAxis
-            tick={{ fontSize: 12, fill: "rgba(255,255,255,0.5)" }}
-            axisLine={false}
-            tickLine={false}
-            tickFormatter={yAxisFormatter}
-            width={60}
-          />
-          {showTooltip && (
-            <Tooltip
-              contentStyle={{
-                backgroundColor: "rgba(17, 24, 39, 0.95)",
-                border: "1px solid rgba(255,255,255,0.1)",
-                borderRadius: "8px",
-                fontSize: "12px",
-              }}
-              labelStyle={{ color: "rgba(255,255,255,0.7)" }}
-              formatter={(value: number) => [tooltipFormatter(value), ""]}
-            />
-          )}
-          <Bar dataKey={dataKey} fill={color} barSize={barSize} radius={radius}>
-            {colors &&
-              data.map((_, index) => (
-                <Cell key={`cell-${index}`} fill={colors[index % colors.length]} />
-              ))}
-          </Bar>
-        </ReBarChart>
-      </ResponsiveContainer>
-    </div>
+        )}
+        <Bar dataKey={dataKey} fill={seriesColor} barSize={barSize} radius={radius}>
+          {colors &&
+            data.map((_, index) => (
+              <Cell
+                key={`cell-${index}`}
+                fill={colors[index % colors.length]}
+              />
+            ))}
+          {!colors &&
+            data.map((_, index) => (
+              <Cell
+                key={`cell-${index}`}
+                fill={resolveColor(index, theme.series)}
+              />
+            ))}
+        </Bar>
+      </ReBarChart>
+    </ChartContainer>
   );
 }

--- a/src/charts/ComposedChart.tsx
+++ b/src/charts/ComposedChart.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import {
   ComposedChart as ReComposedChart,
   Line,
@@ -7,16 +7,17 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
-  ResponsiveContainer,
   Legend,
 } from "recharts";
+import { ChartContainer, ChartTooltip, useChartTheme } from "@/visualizations";
+import type { ChartAccessibility } from "@/visualizations";
 
 export interface ComposedDataPoint {
   label: string;
   [key: string]: string | number;
 }
 
-interface SeriesConfig {
+export interface SeriesConfig {
   key: string;
   type: "line" | "bar";
   color: string;
@@ -36,6 +37,8 @@ interface ComposedChartProps {
   yAxisFormatterRight?: (value: number) => string;
   tooltipFormatter?: (value: number, name: string) => [string, string];
   className?: string;
+  title?: string;
+  accessibility?: ChartAccessibility;
 }
 
 export function ComposedChart({
@@ -50,86 +53,95 @@ export function ComposedChart({
   yAxisFormatterRight = (v) => v.toFixed(2),
   tooltipFormatter = (value, name) => [value.toFixed(4), name],
   className = "",
+  title,
+  accessibility,
 }: ComposedChartProps) {
-  const hasRightAxis = series.some((s) => s.yAxisId === "right");
+  const theme = useChartTheme();
+  const hasRightAxis = useMemo(
+    () => series.some((s) => s.yAxisId === "right"),
+    [series]
+  );
 
   return (
-    <div className={`w-full ${className}`}>
-      <ResponsiveContainer width="100%" height={height}>
-        <ReComposedChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
-          {showGrid && (
-            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
-          )}
-          <XAxis
-            dataKey={labelKey}
-            tick={{ fontSize: 12, fill: "rgba(255,255,255,0.5)" }}
-            axisLine={{ stroke: "rgba(255,255,255,0.1)" }}
-            tickLine={false}
-            minTickGap={30}
-          />
+    <ChartContainer
+      data={data}
+      title={title}
+      height={height}
+      className={className}
+      accessibility={accessibility}
+    >
+      <ReComposedChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+        {showGrid && <CartesianGrid strokeDasharray="3 3" stroke={theme.grid} />}
+        <XAxis
+          dataKey={labelKey}
+          tick={{ fontSize: 12, fill: theme.muted }}
+          axisLine={{ stroke: theme.axis }}
+          tickLine={false}
+          minTickGap={30}
+        />
+        <YAxis
+          yAxisId="left"
+          tick={{ fontSize: 12, fill: theme.muted }}
+          axisLine={false}
+          tickLine={false}
+          tickFormatter={yAxisFormatterLeft}
+          width={60}
+        />
+        {hasRightAxis && (
           <YAxis
-            yAxisId="left"
-            tick={{ fontSize: 12, fill: "rgba(255,255,255,0.5)" }}
+            yAxisId="right"
+            orientation="right"
+            tick={{ fontSize: 12, fill: theme.muted }}
             axisLine={false}
             tickLine={false}
-            tickFormatter={yAxisFormatterLeft}
+            tickFormatter={yAxisFormatterRight}
             width={60}
           />
-          {hasRightAxis && (
-            <YAxis
-              yAxisId="right"
-              orientation="right"
-              tick={{ fontSize: 12, fill: "rgba(255,255,255,0.5)" }}
-              axisLine={false}
-              tickLine={false}
-              tickFormatter={yAxisFormatterRight}
-              width={60}
-            />
-          )}
-          {showTooltip && (
-            <Tooltip
-              contentStyle={{
-                backgroundColor: "rgba(17, 24, 39, 0.95)",
-                border: "1px solid rgba(255,255,255,0.1)",
-                borderRadius: "8px",
-                fontSize: "12px",
-              }}
-              labelStyle={{ color: "rgba(255,255,255,0.7)" }}
-              formatter={(value: number, name: string) => tooltipFormatter(value, name)}
-            />
-          )}
-          {showLegend && (
-            <Legend
-              wrapperStyle={{ fontSize: "12px", color: "rgba(255,255,255,0.7)" }}
-            />
-          )}
-          {series.map((s) =>
-            s.type === "line" ? (
-              <Line
-                key={s.key}
-                type="monotone"
-                dataKey={s.key}
-                stroke={s.color}
-                strokeWidth={2}
-                yAxisId={s.yAxisId || "left"}
-                name={s.name}
-                dot={false}
-                activeDot={{ r: 4, fill: s.color, stroke: "#fff", strokeWidth: 2 }}
+        )}
+        {showTooltip && (
+          <Tooltip
+            content={
+              <ChartTooltip
+                formatter={(value, name) => {
+                  const [v, n] = tooltipFormatter(Number(value), String(name));
+                  return `${v} (${n})`;
+                }}
               />
-            ) : (
-              <Bar
-                key={s.key}
-                dataKey={s.key}
-                fill={s.color}
-                yAxisId={s.yAxisId || "left"}
-                name={s.name}
-                barSize={20}
-                radius={[4, 4, 0, 0]}
-              />
-            )
-          )}
-        </ReComposedChart>
-      </ResponsiveContainer>
-    </div>
+            }
+          />
+        )}
+        {showLegend && (
+          <Legend
+            wrapperStyle={{ fontSize: "12px", color: theme.foreground }}
+            formatter={(value) => <span style={{ color: theme.foreground }}>{value}</span>}
+          />
+        )}
+        {series.map((s) =>
+          s.type === "line" ? (
+            <Line
+              key={s.key}
+              type="monotone"
+              dataKey={s.key}
+              stroke={s.color}
+              strokeWidth={2}
+              yAxisId={s.yAxisId || "left"}
+              name={s.name}
+              dot={false}
+              activeDot={{ r: 4, fill: s.color, stroke: theme.background, strokeWidth: 2 }}
+            />
+          ) : (
+            <Bar
+              key={s.key}
+              dataKey={s.key}
+              fill={s.color}
+              yAxisId={s.yAxisId || "left"}
+              name={s.name}
+              barSize={20}
+              radius={[4, 4, 0, 0]}
+            />
+          )
+        )}
+      </ReComposedChart>
+    </ChartContainer>
   );
 }

--- a/src/charts/LineChart.tsx
+++ b/src/charts/LineChart.tsx
@@ -6,11 +6,12 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
-  ResponsiveContainer,
   Area,
   AreaChart,
   ReferenceLine,
 } from "recharts";
+import { ChartContainer, ChartTooltip, useChartTheme, gradientId } from "@/visualizations";
+import type { ChartAccessibility } from "@/visualizations";
 
 export interface LineChartDataPoint {
   label: string;
@@ -36,15 +37,17 @@ interface LineChartProps {
   strokeWidth?: number;
   referenceValue?: number;
   referenceLabel?: string;
+  title?: string;
+  accessibility?: ChartAccessibility;
 }
 
 export function LineChart({
   data,
   dataKey = "value",
   labelKey = "label",
-  color = "#6366f1",
-  gradientFrom = "#6366f1",
-  gradientTo = "#6366f1",
+  color,
+  gradientFrom,
+  gradientTo,
   showGrid = true,
   showTooltip = true,
   showAverage = false,
@@ -56,7 +59,18 @@ export function LineChart({
   strokeWidth = 2,
   referenceValue,
   referenceLabel,
+  title,
+  accessibility,
 }: LineChartProps) {
+  const theme = useChartTheme();
+  const seriesColor = useMemo(
+    () => color || theme.series[0],
+    [color, theme.series]
+  );
+  const fromColor = gradientFrom || seriesColor;
+  const toColor = gradientTo || seriesColor;
+  const gid = useMemo(() => gradientId(dataKey), [dataKey]);
+
   const average = useMemo(() => {
     if (!showAverage || data.length === 0) return null;
     return data.reduce((sum, d) => sum + (d[dataKey] as number), 0) / data.length;
@@ -65,93 +79,88 @@ export function LineChart({
   const ChartComponent = isArea ? AreaChart : ReLineChart;
 
   return (
-    <div className={`w-full ${className}`}>
-      <ResponsiveContainer width="100%" height={height}>
-        <ChartComponent data={data} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
-          <defs>
-            <linearGradient id={`gradient-${dataKey}`} x1="0" y1="0" x2="0" y2="1">
-              <stop offset="5%" stopColor={gradientFrom} stopOpacity={0.3} />
-              <stop offset="95%" stopColor={gradientTo} stopOpacity={0} />
-            </linearGradient>
-          </defs>
-          {showGrid && (
-            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
-          )}
-          <XAxis
-            dataKey={labelKey}
-            tick={{ fontSize: 12, fill: "rgba(255,255,255,0.5)" }}
-            axisLine={{ stroke: "rgba(255,255,255,0.1)" }}
-            tickLine={false}
-            minTickGap={30}
+    <ChartContainer
+      data={data}
+      title={title}
+      height={height}
+      className={className}
+      accessibility={accessibility}
+    >
+      <ChartComponent data={data} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+        <defs>
+          <linearGradient id={gid} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor={fromColor} stopOpacity={0.3} />
+            <stop offset="95%" stopColor={toColor} stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        {showGrid && <CartesianGrid strokeDasharray="3 3" stroke={theme.grid} />}
+        <XAxis
+          dataKey={labelKey}
+          tick={{ fontSize: 12, fill: theme.muted }}
+          axisLine={{ stroke: theme.axis }}
+          tickLine={false}
+          minTickGap={30}
+        />
+        <YAxis
+          tick={{ fontSize: 12, fill: theme.muted }}
+          axisLine={false}
+          tickLine={false}
+          tickFormatter={yAxisFormatter}
+          width={60}
+        />
+        {showTooltip && (
+          <Tooltip
+            content={<ChartTooltip formatter={(value) => tooltipFormatter(Number(value))} />}
           />
-          <YAxis
-            tick={{ fontSize: 12, fill: "rgba(255,255,255,0.5)" }}
-            axisLine={false}
-            tickLine={false}
-            tickFormatter={yAxisFormatter}
-            width={60}
+        )}
+        {average !== null && (
+          <ReferenceLine
+            y={average}
+            stroke={theme.muted}
+            strokeDasharray="4 4"
+            label={{
+              value: `Avg: ${yAxisFormatter(average)}`,
+              position: "insideTopRight",
+              fill: theme.muted,
+              fontSize: 11,
+            }}
           />
-          {showTooltip && (
-            <Tooltip
-              contentStyle={{
-                backgroundColor: "rgba(17, 24, 39, 0.95)",
-                border: "1px solid rgba(255,255,255,0.1)",
-                borderRadius: "8px",
-                fontSize: "12px",
-              }}
-              labelStyle={{ color: "rgba(255,255,255,0.7)" }}
-              formatter={(value: number) => [tooltipFormatter(value), ""]}
-            />
-          )}
-          {average !== null && (
-            <ReferenceLine
-              y={average}
-              stroke="rgba(255,255,255,0.3)"
-              strokeDasharray="4 4"
-              label={{
-                value: `Avg: ${yAxisFormatter(average)}`,
-                position: "insideTopRight",
-                fill: "rgba(255,255,255,0.5)",
-                fontSize: 11,
-              }}
-            />
-          )}
-          {referenceValue !== undefined && (
-            <ReferenceLine
-              y={referenceValue}
-              stroke={color}
-              strokeDasharray="6 3"
-              strokeOpacity={0.5}
-              label={{
-                value: referenceLabel || "Current",
-                position: "insideTopLeft",
-                fill: color,
-                fontSize: 11,
-              }}
-            />
-          )}
-          {isArea ? (
-            <Area
-              type="monotone"
-              dataKey={dataKey}
-              stroke={color}
-              strokeWidth={strokeWidth}
-              fill={`url(#gradient-${dataKey})`}
-              dot={false}
-              activeDot={{ r: 4, fill: color, stroke: "#fff", strokeWidth: 2 }}
-            />
-          ) : (
-            <Line
-              type="monotone"
-              dataKey={dataKey}
-              stroke={color}
-              strokeWidth={strokeWidth}
-              dot={false}
-              activeDot={{ r: 4, fill: color, stroke: "#fff", strokeWidth: 2 }}
-            />
-          )}
-        </ChartComponent>
-      </ResponsiveContainer>
-    </div>
+        )}
+        {referenceValue !== undefined && (
+          <ReferenceLine
+            y={referenceValue}
+            stroke={seriesColor}
+            strokeDasharray="6 3"
+            strokeOpacity={0.5}
+            label={{
+              value: referenceLabel || "Current",
+              position: "insideTopLeft",
+              fill: seriesColor,
+              fontSize: 11,
+            }}
+          />
+        )}
+        {isArea ? (
+          <Area
+            type="monotone"
+            dataKey={dataKey}
+            stroke={seriesColor}
+            strokeWidth={strokeWidth}
+            fill={`url(#${gid})`}
+            dot={false}
+            activeDot={{ r: 4, fill: seriesColor, stroke: theme.background, strokeWidth: 2 }}
+          />
+        ) : (
+          <Line
+            type="monotone"
+            dataKey={dataKey}
+            stroke={seriesColor}
+            strokeWidth={strokeWidth}
+            dot={false}
+            activeDot={{ r: 4, fill: seriesColor, stroke: theme.background, strokeWidth: 2 }}
+          />
+        )}
+      </ChartComponent>
+    </ChartContainer>
   );
 }

--- a/src/charts/PieChart.tsx
+++ b/src/charts/PieChart.tsx
@@ -1,17 +1,12 @@
-import React from "react";
-import {
-  PieChart as RePieChart,
-  Pie,
-  Cell,
-  Tooltip,
-  ResponsiveContainer,
-  Legend,
-} from "recharts";
+import React, { useMemo } from "react";
+import { PieChart as RePieChart, Pie, Cell, Tooltip, Legend } from "recharts";
+import { ChartContainer, ChartTooltip, useChartTheme } from "@/visualizations";
+import type { ChartAccessibility } from "@/visualizations";
 
 export interface PieChartDataPoint {
   name: string;
   value: number;
-  color: string;
+  color?: string;
 }
 
 interface PieChartProps {
@@ -23,6 +18,8 @@ interface PieChartProps {
   outerRadius?: number;
   tooltipFormatter?: (value: number, name: string) => [string, string];
   className?: string;
+  title?: string;
+  accessibility?: ChartAccessibility;
 }
 
 export function PieChart({
@@ -34,43 +31,67 @@ export function PieChart({
   outerRadius = 90,
   tooltipFormatter = (value, name) => [value.toFixed(2), name],
   className = "",
+  title,
+  accessibility,
 }: PieChartProps) {
+  const theme = useChartTheme();
+
+  const total = useMemo(
+    () => data.reduce((sum, d) => sum + d.value, 0),
+    [data]
+  );
+
   return (
-    <div className={`w-full ${className}`}>
-      <ResponsiveContainer width="100%" height={height}>
-        <RePieChart>
-          <Pie
-            data={data}
-            cx="50%"
-            cy="50%"
-            innerRadius={innerRadius}
-            outerRadius={outerRadius}
-            paddingAngle={3}
-            dataKey="value"
-            stroke="none"
-          >
-            {data.map((entry, index) => (
-              <Cell key={`cell-${index}`} fill={entry.color} />
-            ))}
-          </Pie>
-          {showTooltip && (
-            <Tooltip
-              contentStyle={{
-                backgroundColor: "rgba(17, 24, 39, 0.95)",
-                border: "1px solid rgba(255,255,255,0.1)",
-                borderRadius: "8px",
-                fontSize: "12px",
-              }}
-              formatter={(value: number, name: string) => tooltipFormatter(value, name)}
+    <ChartContainer
+      data={data}
+      title={title}
+      height={height}
+      className={className}
+      accessibility={accessibility}
+    >
+      <RePieChart>
+        <Pie
+          data={data}
+          cx="50%"
+          cy="50%"
+          innerRadius={innerRadius}
+          outerRadius={outerRadius}
+          paddingAngle={3}
+          dataKey="value"
+          stroke={theme.background}
+          strokeWidth={2}
+        >
+          {data.map((entry, index) => (
+            <Cell
+              key={`cell-${index}`}
+              fill={entry.color || theme.series[index % theme.series.length]}
             />
-          )}
-          {showLegend && (
-            <Legend
-              wrapperStyle={{ fontSize: "12px", color: "rgba(255,255,255,0.7)" }}
-            />
-          )}
-        </RePieChart>
-      </ResponsiveContainer>
-    </div>
+          ))}
+        </Pie>
+        {showTooltip && (
+          <Tooltip
+            content={
+              <ChartTooltip
+                formatter={(value, name) => {
+                  const [formattedValue, formattedName] = tooltipFormatter(
+                    Number(value),
+                    String(name)
+                  );
+                  return `${formattedValue} (${formattedName})`;
+                }}
+              />
+            }
+          />
+        )}
+        {showLegend && (
+          <Legend
+            wrapperStyle={{ fontSize: "12px", color: theme.foreground }}
+            formatter={(value) => (
+              <span style={{ color: theme.foreground }}>{value}</span>
+            )}
+          />
+        )}
+      </RePieChart>
+    </ChartContainer>
   );
 }

--- a/src/visualizations/__tests__/ChartContainer.test.tsx
+++ b/src/visualizations/__tests__/ChartContainer.test.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ChartContainer } from "../components/ChartContainer";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+
+describe("ChartContainer", () => {
+  function renderWithTheme(ui: React.ReactElement) {
+    return render(<ThemeProvider>{ui}</ThemeProvider>);
+  }
+
+  it("renders title and chart when data is present", () => {
+    renderWithTheme(
+      <ChartContainer
+        data={[{ label: "A", value: 1 }]}
+        title="Test Chart"
+        accessibility={{ label: "Test chart summary" }}
+      >
+        <div data-testid="chart-body">chart</div>
+      </ChartContainer>
+    );
+
+    expect(screen.getByText("Test Chart")).toBeInTheDocument();
+    expect(screen.getByTestId("chart-body")).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "Test chart summary" })).toBeInTheDocument();
+  });
+
+  it("links accessibility descriptions to the chart wrapper", () => {
+    renderWithTheme(
+      <ChartContainer
+        data={[{ label: "A", value: 1 }]}
+        title="Revenue Chart"
+        accessibility={{
+          label: "Revenue chart summary",
+          description: "Shows revenue grouped by month.",
+        }}
+      >
+        <div data-testid="chart-body">chart</div>
+      </ChartContainer>
+    );
+
+    const chart = screen.getByRole("img", { name: "Revenue chart summary" });
+    const descriptionId = chart.getAttribute("aria-describedby");
+
+    expect(descriptionId).toBeTruthy();
+    expect(document.getElementById(descriptionId as string)).toHaveTextContent(
+      "Shows revenue grouped by month."
+    );
+  });
+
+  it("renders empty state when data is empty", () => {
+    renderWithTheme(
+      <ChartContainer data={[]} title="Empty Chart">
+        <div data-testid="chart-body">chart</div>
+      </ChartContainer>
+    );
+
+    expect(screen.getByText("Empty Chart")).toBeInTheDocument();
+    expect(screen.queryByTestId("chart-body")).not.toBeInTheDocument();
+    expect(screen.getByText("No data available for this chart.")).toBeInTheDocument();
+  });
+
+  it("renders loading skeleton when loading", () => {
+    renderWithTheme(
+      <ChartContainer data={[{ label: "A", value: 1 }]} title="Loading Chart" loading>
+        <div data-testid="chart-body">chart</div>
+      </ChartContainer>
+    );
+
+    expect(screen.getByText("Loading Chart")).toBeInTheDocument();
+    expect(screen.queryByTestId("chart-body")).not.toBeInTheDocument();
+  });
+
+  it("renders error state when error is provided", () => {
+    renderWithTheme(
+      <ChartContainer data={[{ label: "A", value: 1 }]} title="Error Chart" error="boom">
+        <div data-testid="chart-body">chart</div>
+      </ChartContainer>
+    );
+
+    expect(screen.getByText("Error Chart")).toBeInTheDocument();
+    expect(screen.getByText("boom")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("can hide the chart from screen readers", () => {
+    renderWithTheme(
+      <ChartContainer
+        data={[{ label: "A", value: 1 }]}
+        title="Hidden Chart"
+        accessibility={{ hidden: true }}
+      >
+        <div data-testid="chart-body">chart</div>
+      </ChartContainer>
+    );
+
+    const chartBody = screen.getByTestId("chart-body");
+    expect(chartBody.closest('[aria-hidden="true"]')).toBeInTheDocument();
+  });
+});

--- a/src/visualizations/__tests__/colors.test.ts
+++ b/src/visualizations/__tests__/colors.test.ts
@@ -1,0 +1,33 @@
+import { gradientId, resolveColor, hexToRgba, generateMonochromePalette } from "../utils/colors";
+import { DEFAULT_SERIES_COLORS } from "../theme";
+
+describe("gradientId", () => {
+  it("prefixes the base key and sanitizes special characters", () => {
+    expect(gradientId("apy")).toBe("vv-gradient-apy");
+    expect(gradientId("net flow")).toBe("vv-gradient-net-flow");
+  });
+});
+
+describe("resolveColor", () => {
+  it("uses the default palette by default", () => {
+    expect(resolveColor(0)).toBe(DEFAULT_SERIES_COLORS[0]);
+  });
+
+  it("uses the provided palette", () => {
+    expect(resolveColor(0, ["#abc"])).toBe("#abc");
+  });
+});
+
+describe("hexToRgba", () => {
+  it("converts a hex color to rgba", () => {
+    expect(hexToRgba("#6366f1", 0.5)).toBe("rgba(99, 102, 241, 0.5)");
+  });
+});
+
+describe("generateMonochromePalette", () => {
+  it("generates the requested number of colors", () => {
+    const palette = generateMonochromePalette("#6366f1", 3);
+    expect(palette).toHaveLength(3);
+    expect(palette.every((c) => c.startsWith("rgb("))).toBe(true);
+  });
+});

--- a/src/visualizations/__tests__/theme.test.ts
+++ b/src/visualizations/__tests__/theme.test.ts
@@ -1,0 +1,62 @@
+import {
+  buildChartTheme,
+  resolveChartThemeMode,
+  getSeriesColor,
+  withOpacity,
+  DEFAULT_SERIES_COLORS,
+} from "../theme";
+
+describe("buildChartTheme", () => {
+  it("returns dark tokens for dark mode", () => {
+    const theme = buildChartTheme("dark");
+    expect(theme.mode).toBe("dark");
+    expect(theme.background).toBe("#020617");
+    expect(theme.foreground).toBe("#f8fafc");
+    expect(theme.series).toEqual(DEFAULT_SERIES_COLORS);
+  });
+
+  it("returns light tokens for light mode", () => {
+    const theme = buildChartTheme("light");
+    expect(theme.mode).toBe("light");
+    expect(theme.background).toBe("#ffffff");
+    expect(theme.foreground).toBe("#0f172a");
+  });
+});
+
+describe("resolveChartThemeMode", () => {
+  it("returns explicit mode when provided", () => {
+    expect(resolveChartThemeMode("dark")).toBe("dark");
+    expect(resolveChartThemeMode("light")).toBe("light");
+  });
+
+  it("falls back to light when document is unavailable", () => {
+    expect(resolveChartThemeMode("system")).toBe("light");
+  });
+});
+
+describe("getSeriesColor", () => {
+  it("returns the color at the given index", () => {
+    expect(getSeriesColor(0)).toBe(DEFAULT_SERIES_COLORS[0]);
+    expect(getSeriesColor(1)).toBe(DEFAULT_SERIES_COLORS[1]);
+  });
+
+  it("wraps around when index exceeds palette length", () => {
+    expect(getSeriesColor(DEFAULT_SERIES_COLORS.length)).toBe(DEFAULT_SERIES_COLORS[0]);
+  });
+
+  it("uses a custom palette when provided", () => {
+    const palette = ["#ff0000", "#00ff00"];
+    expect(getSeriesColor(0, palette)).toBe("#ff0000");
+    expect(getSeriesColor(2, palette)).toBe("#ff0000");
+  });
+});
+
+describe("withOpacity", () => {
+  it("converts a hex color to rgba", () => {
+    expect(withOpacity("#6366f1", 0.5)).toBe("rgba(99, 102, 241, 0.5)");
+  });
+
+  it("passes through non-hex colors", () => {
+    expect(withOpacity("red", 0.5)).toBe("red");
+  });
+});

--- a/src/visualizations/components/ChartContainer.tsx
+++ b/src/visualizations/components/ChartContainer.tsx
@@ -1,0 +1,164 @@
+/**
+ * @module visualizations/components/ChartContainer
+ *
+ * Reusable, theme-aware, accessible chart wrapper used by all framework charts.
+ */
+
+import React, { useMemo } from "react";
+import { ResponsiveContainer } from "recharts";
+import { useChartTheme } from "../hooks/useChartTheme";
+import type {
+  CommonChartProps,
+  ChartStateRenderers,
+  ChartDataPoint,
+} from "../types";
+
+export interface ChartContainerProps extends CommonChartProps {
+  children: React.ReactNode;
+  /** Data used to derive empty state. */
+  data?: ChartDataPoint[] | unknown[];
+  /** Loading flag. */
+  loading?: boolean;
+  /** Error message. */
+  error?: string | null;
+  /** Minimum width before the chart is hidden to avoid tiny renders. */
+  minWidth?: number;
+  /** Custom state renderers. */
+  states?: ChartStateRenderers;
+}
+
+const prefersReducedMotion =
+  typeof window !== "undefined" &&
+  window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+
+export function ChartContainer({
+  children,
+  title,
+  subtitle,
+  height = 300,
+  className = "",
+  data,
+  loading = false,
+  error = null,
+  minWidth = 200,
+  accessibility,
+  states,
+}: ChartContainerProps) {
+  const theme = useChartTheme();
+
+  const isEmpty = useMemo(() => {
+    if (!data || data.length === 0) return true;
+    return false;
+  }, [data]);
+
+  const descriptionId = useMemo(() => {
+    if (!accessibility?.description) return undefined;
+
+    const baseId = (accessibility.label || title || "chart")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/(^-|-$)/g, "");
+
+    return `${baseId || "chart"}-desc`;
+  }, [accessibility?.description, accessibility?.label, title]);
+
+  const ariaProps = useMemo(() => {
+    if (accessibility?.hidden) {
+      return { "aria-hidden": true as const };
+    }
+    return {
+      role: "img" as const,
+      "aria-label": accessibility?.label || title || "Chart",
+      ...(descriptionId ? { "aria-describedby": descriptionId } : {}),
+    };
+  }, [accessibility, title, descriptionId]);
+
+  const containerStyle: React.CSSProperties = {
+    width: "100%",
+    height,
+    minWidth,
+    color: theme.foreground,
+    background: theme.background,
+  };
+
+  if (loading) {
+    return (
+      <div
+        className={`rounded-2xl border p-6 ${className}`}
+        style={{ borderColor: theme.border, background: theme.background }}
+      >
+        {title && <h3 className="text-lg font-semibold mb-1">{title}</h3>}
+        {subtitle && <p className="text-sm mb-4" style={{ color: theme.muted }}>{subtitle}</p>}
+        {states?.loading ?? (
+          <div
+            className="w-full animate-pulse rounded-xl"
+            style={{ height, background: theme.grid }}
+            aria-label="Loading chart"
+          />
+        )}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        className={`rounded-2xl border p-6 ${className}`}
+        style={{ borderColor: "#ef4444", background: "rgba(239, 68, 68, 0.1)" }}
+        role="alert"
+        aria-live="polite"
+      >
+        {title && <h3 className="text-lg font-semibold mb-1">{title}</h3>}
+        <p className="text-sm text-red-300">{error}</p>
+        {states?.error}
+      </div>
+    );
+  }
+
+  if (isEmpty) {
+    return (
+      <div
+        className={`rounded-2xl border p-6 ${className}`}
+        style={{ borderColor: theme.border, background: theme.background }}
+        role="status"
+        aria-live="polite"
+      >
+        {title && <h3 className="text-lg font-semibold mb-1">{title}</h3>}
+        {states?.empty ?? (
+          <p className="text-sm" style={{ color: theme.muted }}>
+            No data available for this chart.
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`rounded-2xl border p-6 ${className}`}
+      style={{ borderColor: theme.border, background: theme.background }}
+      {...ariaProps}
+    >
+      {title && <h3 className="text-lg font-semibold mb-1">{title}</h3>}
+      {subtitle && (
+        <p className="text-sm mb-4" style={{ color: theme.muted }}>
+          {subtitle}
+        </p>
+      )}
+      {accessibility?.description && (
+        <p id={descriptionId} className="sr-only">
+          {accessibility.description}
+        </p>
+      )}
+      <div
+        className={`w-full ${prefersReducedMotion ? "" : "transition-opacity duration-300"}`}
+        style={containerStyle}
+        tabIndex={0}
+      >
+        <ResponsiveContainer width="100%" height="100%">
+          {children as React.ReactElement}
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/src/visualizations/components/ChartLegend.tsx
+++ b/src/visualizations/components/ChartLegend.tsx
@@ -1,0 +1,22 @@
+/**
+ * @module visualizations/components/ChartLegend
+ *
+ * Theme-aware legend formatter for Recharts legends.
+ */
+
+import React from "react";
+import { useChartTheme } from "../hooks/useChartTheme";
+
+export interface ChartLegendProps {
+  value?: string;
+  className?: string;
+}
+
+export function ChartLegend({ value, className = "" }: ChartLegendProps) {
+  const theme = useChartTheme();
+  return (
+    <span className={`text-sm ${className}`} style={{ color: theme.foreground }}>
+      {value}
+    </span>
+  );
+}

--- a/src/visualizations/components/ChartTooltip.tsx
+++ b/src/visualizations/components/ChartTooltip.tsx
@@ -1,0 +1,89 @@
+/**
+ * @module visualizations/components/ChartTooltip
+ *
+ * Theme-aware tooltip content factory for Recharts tooltips.
+ */
+
+import React, { useMemo } from "react";
+import { useChartTheme } from "../hooks/useChartTheme";
+
+export interface ChartTooltipPayloadItem {
+  name?: string;
+  value?: number | string;
+  color?: string;
+  dataKey?: string;
+  payload?: Record<string, unknown>;
+}
+
+export interface ChartTooltipProps {
+  active?: boolean;
+  payload?: ChartTooltipPayloadItem[];
+  label?: string | number;
+  /** Formatter applied to each value. */
+  formatter?: (value: number, name: string, dataKey?: string) => string;
+  /** Optional label formatter. */
+  labelFormatter?: (label: string | number) => string;
+  /** Hides the label row when true. */
+  hideLabel?: boolean;
+}
+
+const prefersReducedMotion =
+  typeof window !== "undefined" &&
+  window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+
+export function ChartTooltip({
+  active,
+  payload,
+  label,
+  formatter = (v) => (typeof v === "number" ? v.toFixed(2) : String(v)),
+  labelFormatter = (l) => String(l),
+  hideLabel = false,
+}: ChartTooltipProps) {
+  const theme = useChartTheme();
+
+  const items = useMemo(() => {
+    if (!payload || payload.length === 0) return [];
+    return payload
+      .filter((item) => item.value !== undefined && item.value !== null)
+      .map((item) => ({
+        name: item.name || item.dataKey || "Value",
+        value: formatter(Number(item.value), item.name || "Value", item.dataKey),
+        color: item.color || theme.foreground,
+      }));
+  }, [payload, formatter, theme.foreground]);
+
+  if (!active || items.length === 0) return null;
+
+  return (
+    <div
+      className={`rounded-lg border p-3 shadow-lg ${prefersReducedMotion ? "" : "backdrop-blur-sm"}`}
+      style={{
+        backgroundColor: theme.tooltipBg,
+        borderColor: theme.tooltipBorder,
+        color: theme.tooltipFg,
+        fontSize: "12px",
+        minWidth: "120px",
+      }}
+    >
+      {!hideLabel && label !== undefined && (
+        <p className="mb-2 text-xs" style={{ color: theme.muted }}>
+          {labelFormatter(label)}
+        </p>
+      )}
+      <ul className="space-y-1">
+        {items.map((item, index) => (
+          <li key={`${item.name}-${index}`} className="flex items-center justify-between gap-4">
+            <span className="flex items-center gap-2">
+              <span
+                className="inline-block h-2 w-2 rounded-full"
+                style={{ backgroundColor: item.color }}
+              />
+              {item.name}
+            </span>
+            <span className="font-semibold tabular-nums">{item.value}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/visualizations/components/EmptyState.tsx
+++ b/src/visualizations/components/EmptyState.tsx
@@ -1,0 +1,34 @@
+/**
+ * @module visualizations/components/EmptyState
+ *
+ * Consistent empty-state placeholder for charts.
+ */
+
+import React from "react";
+import { useChartTheme } from "../hooks/useChartTheme";
+
+export interface EmptyStateProps {
+  message?: string;
+  icon?: React.ReactNode;
+  className?: string;
+}
+
+export function EmptyState({
+  message = "No data available",
+  icon,
+  className = "",
+}: EmptyStateProps) {
+  const theme = useChartTheme();
+
+  return (
+    <div
+      className={`flex flex-col items-center justify-center rounded-2xl border p-8 ${className}`}
+      style={{ borderColor: theme.border, background: theme.background, color: theme.muted }}
+      role="status"
+      aria-live="polite"
+    >
+      {icon && <div className="mb-3 opacity-60">{icon}</div>}
+      <p className="text-sm">{message}</p>
+    </div>
+  );
+}

--- a/src/visualizations/hooks/useChartTheme.ts
+++ b/src/visualizations/hooks/useChartTheme.ts
@@ -1,0 +1,73 @@
+/**
+ * @module visualizations/hooks/useChartTheme
+ *
+ * React hook for resolving theme-aware chart tokens.
+ */
+
+import { useMemo, useSyncExternalStore } from "react";
+import { buildChartTheme, resolveChartThemeMode } from "../theme";
+import type { ChartThemeMode, ChartThemeTokens } from "../types";
+
+interface UseChartThemeOptions {
+  /** Explicit mode; falls back to the document theme. */
+  mode?: ChartThemeMode | "system";
+}
+
+function getDocumentTheme(): ChartThemeMode {
+  if (typeof document === "undefined") return "light";
+  const attr = document.documentElement.getAttribute("data-theme");
+  if (attr === "dark" || attr === "light") return attr as ChartThemeMode;
+  if (window.matchMedia?.("(prefers-color-scheme: dark)").matches) return "dark";
+  return "light";
+}
+
+function subscribeToThemeChanges(callback: () => void): () => void {
+  if (typeof document === "undefined") return () => {};
+
+  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+  const observer = new MutationObserver(callback);
+
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["data-theme"],
+  });
+  mediaQuery.addEventListener("change", callback);
+
+  return () => {
+    observer.disconnect();
+    mediaQuery.removeEventListener("change", callback);
+  };
+}
+
+/**
+ * Returns theme tokens based on the document `data-theme` attribute or an
+ * explicit override. Works inside or outside the app's ThemeProvider.
+ */
+export function useChartTheme(options: UseChartThemeOptions = {}): ChartThemeTokens {
+  const { mode } = options;
+  const documentMode = useSyncExternalStore(
+    subscribeToThemeChanges,
+    getDocumentTheme,
+    () => "light" as ChartThemeMode
+  );
+
+  return useMemo(() => {
+    const resolved: ChartThemeMode = mode && mode !== "system" ? mode : documentMode;
+    return buildChartTheme(resolved);
+  }, [mode, documentMode]);
+}
+
+/**
+ * Returns the currently resolved light/dark mode without full tokens.
+ */
+export function useChartThemeMode(options: UseChartThemeOptions = {}): ChartThemeMode {
+  const { mode } = options;
+  const documentMode = useSyncExternalStore(
+    subscribeToThemeChanges,
+    getDocumentTheme,
+    () => "light" as ChartThemeMode
+  );
+
+  const resolved: ChartThemeMode = mode && mode !== "system" ? mode : documentMode;
+  return resolved;
+}

--- a/src/visualizations/index.ts
+++ b/src/visualizations/index.ts
@@ -1,0 +1,44 @@
+/**
+ * @module visualizations
+ *
+ * Dashboard visualization framework public API.
+ *
+ * Provides theme-aware, accessible primitives and helpers for building
+ * consistent charts and statistical visualizations across the dashboard.
+ */
+
+// Theme and tokens
+export {
+  DEFAULT_SERIES_COLORS,
+  COLORBLIND_SERIES_COLORS,
+  buildChartTheme,
+  resolveChartThemeMode,
+  getSeriesColor,
+  withOpacity,
+} from "./theme";
+
+// Hooks
+export { useChartTheme, useChartThemeMode } from "./hooks/useChartTheme";
+
+// Utilities
+export { gradientId, resolveColor, hexToRgba, generateMonochromePalette } from "./utils/colors";
+
+// Components
+export { ChartContainer } from "./components/ChartContainer";
+export { ChartTooltip } from "./components/ChartTooltip";
+export { ChartLegend } from "./components/ChartLegend";
+export { EmptyState } from "./components/EmptyState";
+
+// Types
+export type {
+  ChartThemeMode,
+  ChartDataPoint,
+  ChartSeries,
+  ChartAccessibility,
+  CommonChartProps,
+  ChartThemeTokens,
+  ChartStateRenderers,
+} from "./types";
+
+export type { ChartContainerProps } from "./components/ChartContainer";
+export type { ChartTooltipProps } from "./components/ChartTooltip";

--- a/src/visualizations/theme.ts
+++ b/src/visualizations/theme.ts
@@ -1,0 +1,80 @@
+/**
+ * @module visualizations/theme
+ *
+ * Theme tokens, color scales, and helpers for the visualization framework.
+ */
+
+import type { ChartThemeMode, ChartThemeTokens } from "./types";
+
+/** Default color palette used when no explicit colors are provided. */
+export const DEFAULT_SERIES_COLORS = [
+  "#6366f1", // indigo
+  "#10b981", // emerald
+  "#f59e0b", // amber
+  "#ef4444", // red
+  "#a855f7", // purple
+  "#06b6d4", // cyan
+  "#ec4899", // pink
+  "#84cc16", // lime
+];
+
+/** Color-blind friendly palette alternative. */
+export const COLORBLIND_SERIES_COLORS = [
+  "#0173b2",
+  "#de8f05",
+  "#029e73",
+  "#d55e00",
+  "#cc78bc",
+  "#ca9161",
+  "#fbafe4",
+  "#949494",
+];
+
+/** Build a deterministic theme token set for the given mode. */
+export function buildChartTheme(mode: ChartThemeMode): ChartThemeTokens {
+  const isDark = mode === "dark";
+  return {
+    mode,
+    background: isDark ? "#020617" : "#ffffff",
+    foreground: isDark ? "#f8fafc" : "#0f172a",
+    muted: isDark ? "#94a3b8" : "#64748b",
+    grid: isDark ? "rgba(148, 163, 184, 0.1)" : "rgba(100, 116, 139, 0.15)",
+    axis: isDark ? "#334155" : "#cbd5e1",
+    border: isDark ? "rgba(255, 255, 255, 0.1)" : "rgba(0, 0, 0, 0.1)",
+    tooltipBg: isDark ? "rgba(15, 23, 42, 0.95)" : "rgba(255, 255, 255, 0.98)",
+    tooltipBorder: isDark ? "#334155" : "#e2e8f0",
+    tooltipFg: isDark ? "#f1f5f9" : "#0f172a",
+    series: DEFAULT_SERIES_COLORS,
+  };
+}
+
+/** Resolve a theme mode from an explicit value or from the document. */
+export function resolveChartThemeMode(mode?: ChartThemeMode | "system"): ChartThemeMode {
+  if (mode && mode !== "system") return mode;
+  if (typeof document !== "undefined") {
+    const attr = document.documentElement.getAttribute("data-theme");
+    if (attr === "dark" || attr === "light") return attr;
+    if (window.matchMedia?.("(prefers-color-scheme: dark)").matches) return "dark";
+  }
+  return "light";
+}
+
+/** Pick a color from a palette deterministically by index. */
+export function getSeriesColor(index: number, palette?: string[]): string {
+  const colors = palette && palette.length > 0 ? palette : DEFAULT_SERIES_COLORS;
+  return colors[index % colors.length];
+}
+
+/** Build an alpha-adjusted hex/rgb color string for area fills. */
+export function withOpacity(color: string, opacity: number): string {
+  if (color.startsWith("#") && color.length === 7) {
+    const r = parseInt(color.slice(1, 3), 16);
+    const g = parseInt(color.slice(3, 5), 16);
+    const b = parseInt(color.slice(5, 7), 16);
+    return `rgba(${r}, ${g}, ${b}, ${opacity})`;
+  }
+  if (color.startsWith("rgb(")) {
+    return color.replace("rgb(", "rgba(").replace(")", `, ${opacity})`);
+  }
+  return color;
+}

--- a/src/visualizations/types.ts
+++ b/src/visualizations/types.ts
@@ -1,0 +1,78 @@
+/**
+ * @module visualizations/types
+ *
+ * Shared type definitions for the dashboard visualization framework.
+ */
+
+/** Available chart color themes. */
+export type ChartThemeMode = "light" | "dark";
+
+/** Base data point accepted by most chart components. */
+export interface ChartDataPoint {
+  /** Category or timestamp label displayed on the x-axis. */
+  label: string;
+  /** Primary numeric value. */
+  value: number;
+  /** Any additional numeric or string fields for multi-series charts. */
+  [key: string]: string | number;
+}
+
+/** Configuration for a single series in a multi-series chart. */
+export interface ChartSeries {
+  /** Data key mapped to this series. */
+  key: string;
+  /** Human-readable series name used by legends and tooltips. */
+  name: string;
+  /** Render type. */
+  type: "line" | "bar" | "area";
+  /** Stroke/fill color. */
+  color: string;
+  /** Optional y-axis side. */
+  yAxisId?: "left" | "right";
+}
+
+/** Accessibility metadata for a chart. */
+export interface ChartAccessibility {
+  /** Accessible name describing the chart. */
+  label?: string;
+  /** Optional longer description. */
+  description?: string;
+  /** Whether to hide the chart from screen readers (e.g. decorative). */
+  hidden?: boolean;
+}
+
+/** Common props shared by framework chart components. */
+export interface CommonChartProps {
+  /** Chart title rendered above the visualization. */
+  title?: string;
+  /** Optional subtitle or helper text. */
+  subtitle?: string;
+  /** Explicit chart height; defaults to 300. */
+  height?: number;
+  /** Additional CSS classes. */
+  className?: string;
+  /** Accessibility metadata. */
+  accessibility?: ChartAccessibility;
+}
+
+/** Theme-aware color tokens for charts. */
+export interface ChartThemeTokens {
+  mode: ChartThemeMode;
+  background: string;
+  foreground: string;
+  muted: string;
+  grid: string;
+  axis: string;
+  border: string;
+  tooltipBg: string;
+  tooltipBorder: string;
+  tooltipFg: string;
+  series: string[];
+}
+
+/** Loading/error/empty state renderers. */
+export interface ChartStateRenderers {
+  loading?: React.ReactNode;
+  empty?: React.ReactNode;
+  error?: React.ReactNode;
+}

--- a/src/visualizations/utils/colors.ts
+++ b/src/visualizations/utils/colors.ts
@@ -1,0 +1,45 @@
+/**
+ * @module visualizations/utils/colors
+ *
+ * Color helpers used by the visualization framework.
+ */
+
+import { DEFAULT_SERIES_COLORS } from "../theme";
+
+/** Generate a stable gradient id from a base key. */
+export function gradientId(base: string): string {
+  return `vv-gradient-${base.replace(/[^a-zA-Z0-9-]/g, "-")}`;
+}
+
+/** Pick a deterministic color for a series index. */
+export function resolveColor(index: number, palette?: string[]): string {
+  const colors = palette && palette.length > 0 ? palette : DEFAULT_SERIES_COLORS;
+  return colors[index % colors.length];
+}
+
+/** Convert a hex color to an rgba string with the given alpha. */
+export function hexToRgba(hex: string, alpha: number): string {
+  const sanitized = hex.replace("#", "");
+  const bigint = parseInt(sanitized, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+/** Build a bar color palette from a single base hue by varying lightness. */
+export function generateMonochromePalette(baseColor: string, steps: number): string[] {
+  const rgba = hexToRgba(baseColor, 1).replace(")", "").split("(")[1].split(",");
+  const r = parseInt(rgba[0].trim(), 10);
+  const g = parseInt(rgba[1].trim(), 10);
+  const b = parseInt(rgba[2].trim(), 10);
+
+  const palette: string[] = [];
+  for (let i = 0; i < steps; i++) {
+    const factor = 0.4 + (i / Math.max(1, steps - 1)) * 0.6;
+    palette.push(
+      `rgb(${Math.round(r * factor)}, ${Math.round(g * factor)}, ${Math.round(b * factor)})`
+    );
+  }
+  return palette;
+}

--- a/tests/charts/BarChart.test.tsx
+++ b/tests/charts/BarChart.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { BarChart } from "@/charts/BarChart";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+
+const sampleData = [
+  { label: "A", value: 10 },
+  { label: "B", value: 20 },
+];
+
+describe("BarChart", () => {
+  function renderChart(props = {}) {
+    return render(
+      <ThemeProvider>
+        <BarChart data={sampleData} title="Bar Chart" {...props} />
+      </ThemeProvider>
+    );
+  }
+
+  it("renders the chart title", () => {
+    renderChart();
+    expect(screen.getByText("Bar Chart")).toBeInTheDocument();
+  });
+
+  it("renders as an accessible image", () => {
+    renderChart({ accessibility: { label: "Bar chart summary" } });
+    expect(screen.getByRole("img", { name: "Bar chart summary" })).toBeInTheDocument();
+  });
+
+  it("renders empty state when data is empty", () => {
+    renderChart({ data: [] });
+    expect(screen.getByText("No data available for this chart.")).toBeInTheDocument();
+  });
+});

--- a/tests/charts/ComposedChart.test.tsx
+++ b/tests/charts/ComposedChart.test.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ComposedChart } from "@/charts/ComposedChart";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+
+const sampleData = [
+  { label: "A", revenue: 10, users: 100 },
+  { label: "B", revenue: 20, users: 150 },
+];
+
+const series = [
+  { key: "revenue", type: "bar" as const, color: "#6366f1", name: "Revenue" },
+  { key: "users", type: "line" as const, color: "#10b981", name: "Users" },
+];
+
+describe("ComposedChart", () => {
+  function renderChart(props = {}) {
+    return render(
+      <ThemeProvider>
+        <ComposedChart data={sampleData} series={series} title="Composed Chart" {...props} />
+      </ThemeProvider>
+    );
+  }
+
+  it("renders the chart title", () => {
+    renderChart();
+    expect(screen.getByText("Composed Chart")).toBeInTheDocument();
+  });
+
+  it("renders as an accessible image", () => {
+    renderChart({ accessibility: { label: "Composed chart summary" } });
+    expect(screen.getByRole("img", { name: "Composed chart summary" })).toBeInTheDocument();
+  });
+
+  it("renders empty state when data is empty", () => {
+    renderChart({ data: [] });
+    expect(screen.getByText("No data available for this chart.")).toBeInTheDocument();
+  });
+});

--- a/tests/charts/LineChart.test.tsx
+++ b/tests/charts/LineChart.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { LineChart } from "@/charts/LineChart";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+
+const sampleData = [
+  { label: "A", value: 10 },
+  { label: "B", value: 20 },
+];
+
+describe("LineChart", () => {
+  function renderChart(props = {}) {
+    return render(
+      <ThemeProvider>
+        <LineChart data={sampleData} title="Line Chart" {...props} />
+      </ThemeProvider>
+    );
+  }
+
+  it("renders the chart title", () => {
+    renderChart();
+    expect(screen.getByText("Line Chart")).toBeInTheDocument();
+  });
+
+  it("renders as an accessible image", () => {
+    renderChart({ accessibility: { label: "Line chart summary" } });
+    expect(screen.getByRole("img", { name: "Line chart summary" })).toBeInTheDocument();
+  });
+
+  it("renders empty state when data is empty", () => {
+    renderChart({ data: [] });
+    expect(screen.getByText("No data available for this chart.")).toBeInTheDocument();
+  });
+});

--- a/tests/charts/PieChart.test.tsx
+++ b/tests/charts/PieChart.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { PieChart } from "@/charts/PieChart";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+
+const sampleData = [
+  { name: "A", value: 10, color: "#6366f1" },
+  { name: "B", value: 20, color: "#10b981" },
+];
+
+describe("PieChart", () => {
+  function renderChart(props = {}) {
+    return render(
+      <ThemeProvider>
+        <PieChart data={sampleData} title="Pie Chart" {...props} />
+      </ThemeProvider>
+    );
+  }
+
+  it("renders the chart title", () => {
+    renderChart();
+    expect(screen.getByText("Pie Chart")).toBeInTheDocument();
+  });
+
+  it("renders as an accessible image", () => {
+    renderChart({ accessibility: { label: "Pie chart summary" } });
+    expect(screen.getByRole("img", { name: "Pie chart summary" })).toBeInTheDocument();
+  });
+
+  it("renders empty state when data is empty", () => {
+    renderChart({ data: [] });
+    expect(screen.getByText("No data available for this chart.")).toBeInTheDocument();
+  });
+});

--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -14,6 +14,17 @@ Object.defineProperty(window, "matchMedia", {
   }))
 });
 
+// Mock ResizeObserver for Recharts ResponsiveContainer in jsdom
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+Object.defineProperty(window, "ResizeObserver", {
+  writable: true,
+  value: ResizeObserverMock,
+});
+
 // Mock AppTooltip to avoid Radix UI dependency issues in tests
 jest.mock("@/components/AppTooltip", () => ({
   AppTooltip: ({ children }: { children: React.ReactNode }) => children,


### PR DESCRIPTION
### Summary

Adds a reusable visualization framework for the dashboard and migrates the existing chart wrappers onto it.

### Changes

- Adds shared chart container, tooltip, legend, theme, color, state, and accessibility utilities.
- Migrates bar, line, pie, and composed charts to the shared framework while preserving their existing public props.
- Adds unit tests for the framework and chart wrappers.
- Adds framework documentation for future dashboard visualization work.

### Testing / Verification

- `npm test -- --testPathPattern="visualizations|tests/charts"`
- Browser visual check on desktop and mobile with local sample data.

Known repo-wide `typecheck` and `lint` failures remain in pre-existing files outside this patch.

Closes #253.
