### PR TITLE
Introduce new chart components, utilities, and export features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -9045,7 +9045,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/charts/BarChart.tsx
+++ b/src/charts/BarChart.tsx
@@ -9,6 +9,9 @@ import {
   ResponsiveContainer,
   Cell,
 } from "recharts";
+import { useChartTheme } from "@/hooks/useChartTheme";
+import { ChartWrapper } from "./shared/ChartWrapper";
+import { ChartTooltip } from "./shared/ChartTooltip";
 
 export interface BarChartDataPoint {
   label: string;
@@ -30,9 +33,12 @@ interface BarChartProps {
   className?: string;
   barSize?: number;
   radius?: [number, number, number, number];
+  title?: string;
+  description?: string;
+  isLoading?: boolean;
 }
 
-export function BarChart({
+export const BarChart = React.memo(function BarChart({
   data,
   dataKey = "value",
   labelKey = "label",
@@ -46,23 +52,35 @@ export function BarChart({
   className = "",
   barSize = 24,
   radius = [4, 4, 0, 0],
+  title = "Bar chart",
+  description,
+  isLoading = false,
 }: BarChartProps) {
+  const theme = useChartTheme();
+
   return (
-    <div className={`w-full ${className}`}>
+    <ChartWrapper
+      title={title}
+      description={description}
+      isLoading={isLoading}
+      isEmpty={data.length === 0}
+      height={height}
+      className={className}
+    >
       <ResponsiveContainer width="100%" height={height}>
         <ReBarChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
           {showGrid && (
-            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
+            <CartesianGrid strokeDasharray="3 3" stroke={theme.gridStroke} />
           )}
           <XAxis
             dataKey={labelKey}
-            tick={{ fontSize: 12, fill: "rgba(255,255,255,0.5)" }}
-            axisLine={{ stroke: "rgba(255,255,255,0.1)" }}
+            tick={{ fontSize: 12, fill: theme.axisTickFill }}
+            axisLine={{ stroke: theme.axisLineStroke }}
             tickLine={false}
             minTickGap={30}
           />
           <YAxis
-            tick={{ fontSize: 12, fill: "rgba(255,255,255,0.5)" }}
+            tick={{ fontSize: 12, fill: theme.axisTickFill }}
             axisLine={false}
             tickLine={false}
             tickFormatter={yAxisFormatter}
@@ -70,14 +88,11 @@ export function BarChart({
           />
           {showTooltip && (
             <Tooltip
-              contentStyle={{
-                backgroundColor: "rgba(17, 24, 39, 0.95)",
-                border: "1px solid rgba(255,255,255,0.1)",
-                borderRadius: "8px",
-                fontSize: "12px",
-              }}
-              labelStyle={{ color: "rgba(255,255,255,0.7)" }}
-              formatter={(value: number) => [tooltipFormatter(value), ""]}
+              content={
+                <ChartTooltip
+                  formatter={(value) => tooltipFormatter(value as number)}
+                />
+              }
             />
           )}
           <Bar dataKey={dataKey} fill={color} barSize={barSize} radius={radius}>
@@ -88,6 +103,6 @@ export function BarChart({
           </Bar>
         </ReBarChart>
       </ResponsiveContainer>
-    </div>
+    </ChartWrapper>
   );
-}
+});

--- a/src/charts/ComposedChart.tsx
+++ b/src/charts/ComposedChart.tsx
@@ -10,6 +10,9 @@ import {
   ResponsiveContainer,
   Legend,
 } from "recharts";
+import { useChartTheme } from "@/hooks/useChartTheme";
+import { ChartWrapper } from "./shared/ChartWrapper";
+import { ChartTooltip } from "./shared/ChartTooltip";
 
 export interface ComposedDataPoint {
   label: string;
@@ -36,9 +39,12 @@ interface ComposedChartProps {
   yAxisFormatterRight?: (value: number) => string;
   tooltipFormatter?: (value: number, name: string) => [string, string];
   className?: string;
+  title?: string;
+  description?: string;
+  isLoading?: boolean;
 }
 
-export function ComposedChart({
+export const ComposedChart = React.memo(function ComposedChart({
   data,
   series,
   labelKey = "label",
@@ -50,26 +56,37 @@ export function ComposedChart({
   yAxisFormatterRight = (v) => v.toFixed(2),
   tooltipFormatter = (value, name) => [value.toFixed(4), name],
   className = "",
+  title = "Composed chart",
+  description,
+  isLoading = false,
 }: ComposedChartProps) {
+  const theme = useChartTheme();
   const hasRightAxis = series.some((s) => s.yAxisId === "right");
 
   return (
-    <div className={`w-full ${className}`}>
+    <ChartWrapper
+      title={title}
+      description={description}
+      isLoading={isLoading}
+      isEmpty={data.length === 0}
+      height={height}
+      className={className}
+    >
       <ResponsiveContainer width="100%" height={height}>
         <ReComposedChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
           {showGrid && (
-            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
+            <CartesianGrid strokeDasharray="3 3" stroke={theme.gridStroke} />
           )}
           <XAxis
             dataKey={labelKey}
-            tick={{ fontSize: 12, fill: "rgba(255,255,255,0.5)" }}
-            axisLine={{ stroke: "rgba(255,255,255,0.1)" }}
+            tick={{ fontSize: 12, fill: theme.axisTickFill }}
+            axisLine={{ stroke: theme.axisLineStroke }}
             tickLine={false}
             minTickGap={30}
           />
           <YAxis
             yAxisId="left"
-            tick={{ fontSize: 12, fill: "rgba(255,255,255,0.5)" }}
+            tick={{ fontSize: 12, fill: theme.axisTickFill }}
             axisLine={false}
             tickLine={false}
             tickFormatter={yAxisFormatterLeft}
@@ -79,7 +96,7 @@ export function ComposedChart({
             <YAxis
               yAxisId="right"
               orientation="right"
-              tick={{ fontSize: 12, fill: "rgba(255,255,255,0.5)" }}
+              tick={{ fontSize: 12, fill: theme.axisTickFill }}
               axisLine={false}
               tickLine={false}
               tickFormatter={yAxisFormatterRight}
@@ -88,19 +105,18 @@ export function ComposedChart({
           )}
           {showTooltip && (
             <Tooltip
-              contentStyle={{
-                backgroundColor: "rgba(17, 24, 39, 0.95)",
-                border: "1px solid rgba(255,255,255,0.1)",
-                borderRadius: "8px",
-                fontSize: "12px",
-              }}
-              labelStyle={{ color: "rgba(255,255,255,0.7)" }}
-              formatter={(value: number, name: string) => tooltipFormatter(value, name)}
+              content={
+                <ChartTooltip
+                  formatter={(value, name) =>
+                    tooltipFormatter(value as number, name ?? "")
+                  }
+                />
+              }
             />
           )}
           {showLegend && (
             <Legend
-              wrapperStyle={{ fontSize: "12px", color: "rgba(255,255,255,0.7)" }}
+              wrapperStyle={{ fontSize: "12px", color: theme.axisTickFill }}
             />
           )}
           {series.map((s) =>
@@ -130,6 +146,6 @@ export function ComposedChart({
           )}
         </ReComposedChart>
       </ResponsiveContainer>
-    </div>
+    </ChartWrapper>
   );
-}
+});

--- a/src/charts/HealthLatencyBars.tsx
+++ b/src/charts/HealthLatencyBars.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import type { ProtocolHealthStatus } from "@/services/protocolHealth";
 
 type HealthLatencyBarsProps = {
@@ -13,28 +14,45 @@ const STATUS_CLASS: Record<ProtocolHealthStatus, string> = {
 export default function HealthLatencyBars({ data }: HealthLatencyBarsProps) {
   const maxLatency = Math.max(...data.map((item) => item.latencyMs), 1);
 
+  const srSummary = data
+    .map((item) => `${item.label}: ${item.latencyMs}ms (${item.status})`)
+    .join("; ");
+
   return (
-    <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-950/80">
+    <div
+      className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-950/80"
+      role="img"
+      aria-label={`Endpoint latency chart. ${srSummary}`}
+    >
       <div className="mb-5">
         <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Endpoint Latency</h2>
         <p className="text-sm text-slate-500 dark:text-slate-400">Latest frontend probe response time.</p>
       </div>
-      <div className="space-y-4">
+      <ul role="list" className="space-y-4" aria-label="Endpoint latency bars">
         {data.map((item) => {
           const width = `${Math.max(8, Math.round((item.latencyMs / maxLatency) * 100))}%`;
           return (
-            <div key={item.label}>
+            <li key={item.label} role="listitem">
               <div className="mb-1 flex items-center justify-between text-sm">
                 <span className="font-medium text-slate-700 dark:text-slate-200">{item.label}</span>
-                <span className="tabular-nums text-slate-500 dark:text-slate-400">{item.latencyMs} ms</span>
+                <span className="tabular-nums text-slate-500 dark:text-slate-400">
+                  <span aria-label={`${item.latencyMs} milliseconds`}>{item.latencyMs} ms</span>
+                </span>
               </div>
-              <div className="h-3 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800">
+              <div
+                className="h-3 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800"
+                role="progressbar"
+                aria-valuenow={item.latencyMs}
+                aria-valuemin={0}
+                aria-valuemax={maxLatency}
+                aria-label={`${item.label} latency: ${item.status}`}
+              >
                 <div className={`h-full rounded-full ${STATUS_CLASS[item.status]}`} style={{ width }} />
               </div>
-            </div>
+            </li>
           );
         })}
-      </div>
+      </ul>
     </div>
   );
 }

--- a/src/charts/LineChart.tsx
+++ b/src/charts/LineChart.tsx
@@ -11,6 +11,9 @@ import {
   AreaChart,
   ReferenceLine,
 } from "recharts";
+import { useChartTheme } from "@/hooks/useChartTheme";
+import { ChartWrapper } from "./shared/ChartWrapper";
+import { ChartTooltip } from "./shared/ChartTooltip";
 
 export interface LineChartDataPoint {
   label: string;
@@ -36,9 +39,12 @@ interface LineChartProps {
   strokeWidth?: number;
   referenceValue?: number;
   referenceLabel?: string;
+  title?: string;
+  description?: string;
+  isLoading?: boolean;
 }
 
-export function LineChart({
+export const LineChart = React.memo(function LineChart({
   data,
   dataKey = "value",
   labelKey = "label",
@@ -56,36 +62,49 @@ export function LineChart({
   strokeWidth = 2,
   referenceValue,
   referenceLabel,
+  title = "Line chart",
+  description,
+  isLoading = false,
 }: LineChartProps) {
+  const theme = useChartTheme();
+
   const average = useMemo(() => {
     if (!showAverage || data.length === 0) return null;
     return data.reduce((sum, d) => sum + (d[dataKey] as number), 0) / data.length;
   }, [data, dataKey, showAverage]);
 
   const ChartComponent = isArea ? AreaChart : ReLineChart;
+  const gradientId = `gradient-${dataKey}-${title.replace(/\s+/g, "-")}`;
 
   return (
-    <div className={`w-full ${className}`}>
+    <ChartWrapper
+      title={title}
+      description={description}
+      isLoading={isLoading}
+      isEmpty={data.length === 0}
+      height={height}
+      className={className}
+    >
       <ResponsiveContainer width="100%" height={height}>
         <ChartComponent data={data} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
           <defs>
-            <linearGradient id={`gradient-${dataKey}`} x1="0" y1="0" x2="0" y2="1">
+            <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
               <stop offset="5%" stopColor={gradientFrom} stopOpacity={0.3} />
               <stop offset="95%" stopColor={gradientTo} stopOpacity={0} />
             </linearGradient>
           </defs>
           {showGrid && (
-            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
+            <CartesianGrid strokeDasharray="3 3" stroke={theme.gridStroke} />
           )}
           <XAxis
             dataKey={labelKey}
-            tick={{ fontSize: 12, fill: "rgba(255,255,255,0.5)" }}
-            axisLine={{ stroke: "rgba(255,255,255,0.1)" }}
+            tick={{ fontSize: 12, fill: theme.axisTickFill }}
+            axisLine={{ stroke: theme.axisLineStroke }}
             tickLine={false}
             minTickGap={30}
           />
           <YAxis
-            tick={{ fontSize: 12, fill: "rgba(255,255,255,0.5)" }}
+            tick={{ fontSize: 12, fill: theme.axisTickFill }}
             axisLine={false}
             tickLine={false}
             tickFormatter={yAxisFormatter}
@@ -93,25 +112,22 @@ export function LineChart({
           />
           {showTooltip && (
             <Tooltip
-              contentStyle={{
-                backgroundColor: "rgba(17, 24, 39, 0.95)",
-                border: "1px solid rgba(255,255,255,0.1)",
-                borderRadius: "8px",
-                fontSize: "12px",
-              }}
-              labelStyle={{ color: "rgba(255,255,255,0.7)" }}
-              formatter={(value: number) => [tooltipFormatter(value), ""]}
+              content={
+                <ChartTooltip
+                  formatter={(value) => tooltipFormatter(value as number)}
+                />
+              }
             />
           )}
           {average !== null && (
             <ReferenceLine
               y={average}
-              stroke="rgba(255,255,255,0.3)"
+              stroke={theme.referenceLineColor}
               strokeDasharray="4 4"
               label={{
                 value: `Avg: ${yAxisFormatter(average)}`,
                 position: "insideTopRight",
-                fill: "rgba(255,255,255,0.5)",
+                fill: theme.axisTickFill,
                 fontSize: 11,
               }}
             />
@@ -136,7 +152,7 @@ export function LineChart({
               dataKey={dataKey}
               stroke={color}
               strokeWidth={strokeWidth}
-              fill={`url(#gradient-${dataKey})`}
+              fill={`url(#${gradientId})`}
               dot={false}
               activeDot={{ r: 4, fill: color, stroke: "#fff", strokeWidth: 2 }}
             />
@@ -152,6 +168,6 @@ export function LineChart({
           )}
         </ChartComponent>
       </ResponsiveContainer>
-    </div>
+    </ChartWrapper>
   );
-}
+});

--- a/src/charts/NetworkDiagram.tsx
+++ b/src/charts/NetworkDiagram.tsx
@@ -1,0 +1,276 @@
+import React, { useId, useMemo } from "react";
+import { cn } from "@/lib/utils";
+import type { ProtocolHealthMetric, ProtocolHealthStatus } from "@/services/protocolHealth";
+
+export interface NetworkNode {
+  id: string;
+  label: string;
+  description?: string;
+  status: ProtocolHealthStatus;
+  latencyMs?: number;
+  x: number;
+  y: number;
+}
+
+export interface NetworkEdge {
+  from: string;
+  to: string;
+  label?: string;
+}
+
+interface NetworkDiagramProps {
+  metrics: ProtocolHealthMetric[];
+  nodes?: NetworkNode[];
+  edges?: NetworkEdge[];
+  height?: number;
+  title?: string;
+  description?: string;
+  className?: string;
+}
+
+const STATUS_COLOR: Record<ProtocolHealthStatus, string> = {
+  operational: "#10b981",
+  degraded:    "#f59e0b",
+  down:        "#ef4444",
+};
+
+const STATUS_FILL_OPACITY: Record<ProtocolHealthStatus, number> = {
+  operational: 0.15,
+  degraded:    0.18,
+  down:        0.2,
+};
+
+const DEFAULT_NODES: NetworkNode[] = [
+  { id: "soroban-rpc",      label: "Soroban RPC",       status: "operational", x: 75,  y: 110 },
+  { id: "horizon",          label: "Horizon Indexer",   status: "operational", x: 75,  y: 30  },
+  { id: "contract-config",  label: "Contract Config",   status: "operational", x: 195, y: 70  },
+  { id: "event-stream",     label: "Event Stream",      status: "operational", x: 315, y: 30  },
+  { id: "transaction-flow", label: "Transaction Flow",  status: "operational", x: 315, y: 110 },
+];
+
+const DEFAULT_EDGES: NetworkEdge[] = [
+  { from: "soroban-rpc",     to: "contract-config" },
+  { from: "horizon",         to: "contract-config" },
+  { from: "contract-config", to: "event-stream" },
+  { from: "contract-config", to: "transaction-flow" },
+];
+
+function NodeRadius() {
+  return 22;
+}
+
+export const NetworkDiagram = React.memo(function NetworkDiagram({
+  metrics,
+  nodes: nodesProp,
+  edges = DEFAULT_EDGES,
+  height = 170,
+  title = "Protocol network diagram",
+  description,
+  className,
+}: NetworkDiagramProps) {
+  const uniqueId = useId();
+  const markerId = `arrowhead-${uniqueId.replace(/:/g, "")}`;
+
+  const nodes = useMemo<NetworkNode[]>(() => {
+    const base = nodesProp ?? DEFAULT_NODES;
+    if (metrics.length === 0) return base;
+
+    const metricMap = new Map(metrics.map((m) => [m.id, m]));
+    return base.map((node) => {
+      const metric = metricMap.get(node.id);
+      if (!metric) return node;
+      return {
+        ...node,
+        status: metric.status,
+        latencyMs: metric.latencyMs,
+      };
+    });
+  }, [nodesProp, metrics]);
+
+  const r = NodeRadius();
+  const viewBoxWidth = 390;
+  const viewBoxHeight = height;
+
+  const srText = nodes
+    .map((n) => `${n.label}: ${n.status}${n.latencyMs != null ? ` (${n.latencyMs}ms)` : ""}`)
+    .join("; ");
+
+  const ariaLabel = `${title}. ${description ?? srText}`;
+
+  return (
+    <div className={cn("w-full", className)}>
+      <svg
+        role="img"
+        aria-label={ariaLabel}
+        viewBox={`0 0 ${viewBoxWidth} ${viewBoxHeight}`}
+        preserveAspectRatio="xMidYMid meet"
+        style={{ width: "100%", height }}
+      >
+        <title>{title}</title>
+
+        <defs>
+          <marker
+            id={markerId}
+            markerWidth="8"
+            markerHeight="6"
+            refX="8"
+            refY="3"
+            orient="auto"
+          >
+            <polygon
+              points="0 0, 8 3, 0 6"
+              fill="var(--color-border-primary, #cbd5e1)"
+              opacity={0.6}
+            />
+          </marker>
+        </defs>
+
+        {/* Edges */}
+        {edges.map((edge, i) => {
+          const from = nodes.find((n) => n.id === edge.from);
+          const to   = nodes.find((n) => n.id === edge.to);
+          if (!from || !to) return null;
+
+          const dx = to.x - from.x;
+          const dy = to.y - from.y;
+          const dist = Math.sqrt(dx * dx + dy * dy);
+          const ux = dx / dist;
+          const uy = dy / dist;
+
+          const x1 = from.x + ux * r;
+          const y1 = from.y + uy * r;
+          const x2 = to.x   - ux * (r + 8);
+          const y2 = to.y   - uy * (r + 8);
+
+          return (
+            <line
+              key={i}
+              x1={x1}
+              y1={y1}
+              x2={x2}
+              y2={y2}
+              stroke="var(--color-border-primary, #cbd5e1)"
+              strokeWidth={1.5}
+              strokeOpacity={0.5}
+                markerEnd={`url(#${markerId})`}
+            />
+          );
+        })}
+
+        {/* Nodes */}
+        {nodes.map((node) => {
+          const color   = STATUS_COLOR[node.status];
+          const opacity = STATUS_FILL_OPACITY[node.status];
+          const isPulse = node.status === "degraded" || node.status === "down";
+
+          return (
+            <g key={node.id} aria-label={`${node.label}: ${node.status}`}>
+              {/* Pulse ring for non-operational nodes */}
+              {isPulse && (
+                <circle
+                  cx={node.x}
+                  cy={node.y}
+                  r={r + 6}
+                  fill="none"
+                  stroke={color}
+                  strokeWidth={1.5}
+                  strokeOpacity={0.3}
+                >
+                  <animate
+                    attributeName="r"
+                    values={`${r + 4};${r + 12};${r + 4}`}
+                    dur="2s"
+                    repeatCount="indefinite"
+                  />
+                  <animate
+                    attributeName="stroke-opacity"
+                    values="0.4;0;0.4"
+                    dur="2s"
+                    repeatCount="indefinite"
+                  />
+                </circle>
+              )}
+
+              {/* Node background circle */}
+              <circle
+                cx={node.x}
+                cy={node.y}
+                r={r}
+                fill={color}
+                fillOpacity={opacity}
+                stroke={color}
+                strokeWidth={1.5}
+              />
+
+              {/* Status dot */}
+              <circle
+                cx={node.x + r - 6}
+                cy={node.y - r + 6}
+                r={4}
+                fill={color}
+              />
+
+              {/* Label */}
+              <text
+                x={node.x}
+                y={node.y + r + 14}
+                textAnchor="middle"
+                fontSize={9}
+                fontWeight={500}
+                fill="var(--color-text-secondary, #475569)"
+              >
+                {node.label}
+              </text>
+
+              {/* Latency badge */}
+              {node.latencyMs != null && (
+                <text
+                  x={node.x}
+                  y={node.y - r - 6}
+                  textAnchor="middle"
+                  fontSize={8}
+                  fill="var(--color-text-muted, #94a3b8)"
+                >
+                  {node.latencyMs}ms
+                </text>
+              )}
+
+              {/* Center icon (first letter) */}
+              <text
+                x={node.x}
+                y={node.y + 4}
+                textAnchor="middle"
+                fontSize={13}
+                fontWeight={700}
+                fill={color}
+              >
+                {node.label.charAt(0)}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+
+      {/* Screen-reader text summary */}
+      <p className="sr-only">{srText}</p>
+    </div>
+  );
+});
+
+/**
+ * Adapter: convert ProtocolHealthMetric[] to NetworkNode[] for the diagram.
+ * Preserves the default layout positions while injecting live status data.
+ */
+export function metricsToNetworkGraph(metrics: ProtocolHealthMetric[]): {
+  nodes: NetworkNode[];
+  edges: NetworkEdge[];
+} {
+  const metricMap = new Map(metrics.map((m) => [m.id, m]));
+  const nodes = DEFAULT_NODES.map((node) => {
+    const metric = metricMap.get(node.id);
+    return metric
+      ? { ...node, status: metric.status, latencyMs: metric.latencyMs }
+      : node;
+  });
+  return { nodes, edges: DEFAULT_EDGES };
+}

--- a/src/charts/PieChart.tsx
+++ b/src/charts/PieChart.tsx
@@ -7,6 +7,9 @@ import {
   ResponsiveContainer,
   Legend,
 } from "recharts";
+import { useChartTheme } from "@/hooks/useChartTheme";
+import { ChartWrapper } from "./shared/ChartWrapper";
+import { ChartTooltip } from "./shared/ChartTooltip";
 
 export interface PieChartDataPoint {
   name: string;
@@ -23,9 +26,12 @@ interface PieChartProps {
   outerRadius?: number;
   tooltipFormatter?: (value: number, name: string) => [string, string];
   className?: string;
+  title?: string;
+  description?: string;
+  isLoading?: boolean;
 }
 
-export function PieChart({
+export const PieChart = React.memo(function PieChart({
   data,
   showTooltip = true,
   showLegend = true,
@@ -34,9 +40,21 @@ export function PieChart({
   outerRadius = 90,
   tooltipFormatter = (value, name) => [value.toFixed(2), name],
   className = "",
+  title = "Pie chart",
+  description,
+  isLoading = false,
 }: PieChartProps) {
+  const theme = useChartTheme();
+
   return (
-    <div className={`w-full ${className}`}>
+    <ChartWrapper
+      title={title}
+      description={description}
+      isLoading={isLoading}
+      isEmpty={data.length === 0}
+      height={height}
+      className={className}
+    >
       <ResponsiveContainer width="100%" height={height}>
         <RePieChart>
           <Pie
@@ -55,22 +73,22 @@ export function PieChart({
           </Pie>
           {showTooltip && (
             <Tooltip
-              contentStyle={{
-                backgroundColor: "rgba(17, 24, 39, 0.95)",
-                border: "1px solid rgba(255,255,255,0.1)",
-                borderRadius: "8px",
-                fontSize: "12px",
-              }}
-              formatter={(value: number, name: string) => tooltipFormatter(value, name)}
+              content={
+                <ChartTooltip
+                  formatter={(value, name) =>
+                    tooltipFormatter(value as number, name ?? "")
+                  }
+                />
+              }
             />
           )}
           {showLegend && (
             <Legend
-              wrapperStyle={{ fontSize: "12px", color: "rgba(255,255,255,0.7)" }}
+              wrapperStyle={{ fontSize: "12px", color: theme.axisTickFill }}
             />
           )}
         </RePieChart>
       </ResponsiveContainer>
-    </div>
+    </ChartWrapper>
   );
-}
+});

--- a/src/charts/StatisticsBar.tsx
+++ b/src/charts/StatisticsBar.tsx
@@ -1,0 +1,143 @@
+import React, { useId, useMemo } from "react";
+import { cn } from "@/lib/utils";
+import { useChartTheme } from "@/hooks/useChartTheme";
+
+interface StatisticsBarProps {
+  min: number;
+  max: number;
+  average: number;
+  current?: number;
+  formatter?: (v: number) => string;
+  color?: string;
+  label?: string;
+  height?: number;
+  className?: string;
+}
+
+const defaultFmt = (v: number) => v.toLocaleString(undefined, { maximumFractionDigits: 2 });
+
+export const StatisticsBar = React.memo(function StatisticsBar({
+  min,
+  max,
+  average,
+  current,
+  formatter = defaultFmt,
+  color = "#6366f1",
+  label,
+  height = 60,
+  className,
+}: StatisticsBarProps) {
+  const theme = useChartTheme();
+  const uniqueId = useId();
+  const range = max - min || 1;
+  const safeColor = color.replace(/[^a-zA-Z0-9_-]/g, "");
+  const gradientId = `stat-grad-${safeColor}-${uniqueId.replace(/:/g, "")}`;
+
+  const avgPct   = useMemo(() => ((average - min) / range) * 100, [average, min, range]);
+  const currPct  = useMemo(
+    () => (current != null ? ((current - min) / range) * 100 : null),
+    [current, min, range]
+  );
+
+  const ariaLabel = [
+    label && `${label} distribution.`,
+    `Min: ${formatter(min)},`,
+    `Average: ${formatter(average)},`,
+    `Max: ${formatter(max)}`,
+    current != null ? `, Current: ${formatter(current)}` : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const trackH = 8;
+  const svgW   = 400;
+  const svgH   = height;
+  const barY   = svgH / 2 - trackH / 2;
+
+  return (
+    <div
+      className={cn("w-full", className)}
+      role="img"
+      aria-label={ariaLabel}
+    >
+      {label && (
+        <p className="mb-1 text-xs font-medium text-[var(--color-text-secondary)]">{label}</p>
+      )}
+      <svg
+        viewBox={`0 0 ${svgW} ${svgH}`}
+        preserveAspectRatio="xMidYMid meet"
+        style={{ width: "100%", height }}
+        aria-hidden="true"
+      >
+        <defs>
+          <linearGradient id={gradientId} x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stopColor={color} stopOpacity={0.15} />
+            <stop offset="100%" stopColor={color} stopOpacity={0.55} />
+          </linearGradient>
+        </defs>
+
+        {/* Track background */}
+        <rect
+          x={0}
+          y={barY}
+          width={svgW}
+          height={trackH}
+          rx={trackH / 2}
+          fill={theme.isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.06)"}
+        />
+
+        {/* Filled range */}
+        <rect
+          x={0}
+          y={barY}
+          width={svgW}
+          height={trackH}
+          rx={trackH / 2}
+          fill={`url(#${gradientId})`}
+        />
+
+        {/* Average marker line */}
+        <line
+          x1={(avgPct / 100) * svgW}
+          y1={barY - 6}
+          x2={(avgPct / 100) * svgW}
+          y2={barY + trackH + 6}
+          stroke={color}
+          strokeWidth={2}
+          strokeLinecap="round"
+        />
+
+        {/* Average label */}
+        <text
+          x={(avgPct / 100) * svgW}
+          y={barY - 10}
+          textAnchor="middle"
+          fontSize={9}
+          fill={theme.axisTickFill}
+        >
+          avg {formatter(average)}
+        </text>
+
+        {/* Current value dot */}
+        {currPct != null && (
+          <circle
+            cx={(currPct / 100) * svgW}
+            cy={barY + trackH / 2}
+            r={6}
+            fill={color}
+            stroke="#fff"
+            strokeWidth={2}
+          />
+        )}
+
+        {/* Min / Max labels */}
+        <text x={2} y={svgH - 2} fontSize={9} fill={theme.axisTickFill}>
+          {formatter(min)}
+        </text>
+        <text x={svgW - 2} y={svgH - 2} textAnchor="end" fontSize={9} fill={theme.axisTickFill}>
+          {formatter(max)}
+        </text>
+      </svg>
+    </div>
+  );
+});

--- a/src/charts/VISUALIZATION_GUIDELINES.md
+++ b/src/charts/VISUALIZATION_GUIDELINES.md
@@ -1,0 +1,186 @@
+# Visualization Guidelines
+
+Standards for building and using chart components in the Axionvera Dashboard.
+
+---
+
+## 1. Choosing a Chart Type
+
+| Use Case | Component | Notes |
+|---|---|---|
+| Time series (single metric) | `LineChart` with `isArea` | Use gradient fill for balance/value trends |
+| Time series (multiple metrics) | `ComposedChart` | Supports mixed bar+line with dual Y-axes |
+| Period comparison | `BarChart` | Use `colors[]` for per-bar coloring |
+| Categorical distribution | `PieChart` | Keep slices ≤ 6; group small values as "Other" |
+| Protocol network topology | `NetworkDiagram` | Pass `ProtocolHealthMetric[]` from `protocolHealth.ts` |
+| Statistical range (min/avg/max) | `StatisticsBar` | Use below time-series charts for context |
+| Endpoint latency | `HealthLatencyBars` | Status-colored bars; already includes card shell |
+
+---
+
+## 2. Color Palette
+
+Always use `CHART_COLORS` from `useChartTheme` for series colors. Never hardcode RGBA strings inside chart components.
+
+```ts
+import { CHART_COLORS } from "@/hooks/useChartTheme";
+
+// Order (by semantic priority):
+// [0] #6366f1  indigo   — primary brand / balance
+// [1] #10b981  emerald  — rewards / success
+// [2] #a855f7  purple   — secondary accent
+// [3] #f59e0b  amber    — warning / degraded
+// [4] #ef4444  red      — danger / down
+// [5] #3b82f6  blue     — info
+// [6] #f43f5e  rose     — secondary danger
+// [7] #06b6d4  cyan     — tertiary accent
+```
+
+Status-semantic overrides (protocol health, transaction states):
+- **operational** → `#10b981` (emerald)
+- **degraded** → `#f59e0b` (amber)
+- **down** → `#ef4444` (red)
+
+---
+
+## 3. Theming
+
+Call `useChartTheme()` for all axis, grid, and tooltip tokens:
+
+```ts
+const theme = useChartTheme();
+// theme.gridStroke       — CartesianGrid stroke
+// theme.axisTickFill     — XAxis/YAxis tick fill
+// theme.axisLineStroke   — XAxis axisLine stroke
+// theme.referenceLineColor — ReferenceLine stroke
+// theme.isDark           — boolean if needed for conditional logic
+```
+
+The hook reads from `ThemeContext` and returns light or dark values automatically. Charts wrapped in `ChartWrapper` adapt with no extra work.
+
+---
+
+## 4. Loading States
+
+Replace the chart with `ChartSkeleton` at the same `height` while data loads:
+
+```tsx
+{isLoading
+  ? <ChartSkeleton height={300} />
+  : <LineChart data={data} height={300} />}
+```
+
+Or pass `isLoading` directly to any chart component:
+
+```tsx
+<LineChart data={data} isLoading={isLoading} height={300} />
+```
+
+Never render an empty Recharts chart while loading — it produces invisible axis lines.
+
+---
+
+## 5. Empty States
+
+`LineChart`, `BarChart`, `ComposedChart`, and `PieChart` automatically render an empty state when `data.length === 0`.
+
+```tsx
+<BarChart data={data} height={300} />
+```
+
+If you need a custom empty-state message, wrap the chart content with `ChartWrapper` directly:
+
+```tsx
+<ChartWrapper
+  title="Transactions"
+  isEmpty={data.length === 0}
+  emptyMessage="No transactions in this period"
+  height={300}
+>
+  <BarChart data={data} />
+</ChartWrapper>
+```
+
+---
+
+## 6. Error Handling
+
+Wrap every chart in `ChartErrorBoundary` (or use `ChartWrapper`) when the chart receives runtime data:
+
+```tsx
+<ChartErrorBoundary chartTitle="APY History" onRetry={refetch}>
+  <LineChart data={apyData} />
+</ChartErrorBoundary>
+```
+
+Charts in static demo/preview contexts (e.g., design-system pages) do not need the boundary.
+
+---
+
+## 7. Accessibility
+
+Every chart **must** include:
+
+1. `role="img"` on the outermost wrapper — provided automatically by `ChartWrapper`
+2. `aria-label` describing what the chart shows — set via the `title` and `description` props
+
+```tsx
+<LineChart
+  data={data}
+  title="Balance Trend"
+  description="XLM vault balance over the last 30 days"
+/>
+```
+
+For `NetworkDiagram` and `StatisticsBar`, the accessible description is auto-generated from the data values.
+
+For `HealthLatencyBars`, the `role="progressbar"` on each bar includes `aria-valuenow`, `aria-valuemin`, and `aria-valuemax`.
+
+---
+
+## 8. Performance
+
+- Wrap all data-transform logic in `useMemo` before passing to chart props
+- Import via `LazyComponents.tsx` in page-level components — all charts are `ssr: false`
+- Charts that appear only in a tab or modal should use the `Lazy*` variants
+
+```tsx
+import { LazyPerformanceChart } from "@/components/optimized/LazyComponents";
+
+<LazyPerformanceChart balanceData={data} />
+```
+
+- Prefer `React.memo` on any custom chart that is a direct child of a context consumer
+
+---
+
+## 9. Data Export
+
+Use `chartExport.ts` utilities to add download actions to chart cards:
+
+```ts
+import { exportTimeSeriesCSV, exportToJSON } from "@/utils/chartExport";
+
+// CSV download
+exportTimeSeriesCSV(balanceData, "balance-2025-06-28.csv");
+
+// JSON with metadata
+exportToJSON(analyticsData, "analytics.json", { includeMetadata: true });
+```
+
+Filename convention: `{metric-name}-{YYYY-MM-DD}.{ext}` so downloaded files are self-describing.
+
+---
+
+## 10. Adding a New Chart
+
+Checklist:
+
+- [ ] Create in `src/charts/` (primitive) or `src/components/visualizations/` (domain composition)
+- [ ] Wrap in `ChartWrapper` or apply `role="img"` + `aria-label` manually
+- [ ] Use `useChartTheme()` for all axis/grid/tooltip colors
+- [ ] Use `ChartTooltip` as the Recharts `content` prop
+- [ ] Apply `React.memo` to the exported component
+- [ ] Export from `src/charts/index.ts`
+- [ ] Add a lazy export in `src/components/optimized/LazyComponents.tsx`
+- [ ] Write at minimum: a render smoke test and an `aria-label` assertion

--- a/src/charts/index.ts
+++ b/src/charts/index.ts
@@ -1,4 +1,26 @@
 export { LineChart } from "./LineChart";
+export type { LineChartDataPoint } from "./LineChart";
+
 export { BarChart } from "./BarChart";
+export type { BarChartDataPoint } from "./BarChart";
+
 export { ComposedChart } from "./ComposedChart";
+export type { ComposedDataPoint } from "./ComposedChart";
+
 export { PieChart } from "./PieChart";
+export type { PieChartDataPoint } from "./PieChart";
+
+export { default as HealthLatencyBars } from "./HealthLatencyBars";
+
+export { NetworkDiagram } from "./NetworkDiagram";
+export type { NetworkNode, NetworkEdge } from "./NetworkDiagram";
+
+export { StatisticsBar } from "./StatisticsBar";
+
+export {
+  ChartTooltip,
+  ChartSkeleton,
+  ChartErrorBoundary,
+  ChartEmptyState,
+  ChartWrapper,
+} from "./shared";

--- a/src/charts/shared/ChartEmptyState.tsx
+++ b/src/charts/shared/ChartEmptyState.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+interface ChartEmptyStateProps {
+  message?: string;
+  height?: number;
+  icon?: React.ReactNode;
+  className?: string;
+}
+
+const DefaultIcon = () => (
+  <svg
+    className="h-10 w-10 text-[var(--color-text-muted)]"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    aria-hidden="true"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={1.2}
+      d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"
+    />
+  </svg>
+);
+
+export function ChartEmptyState({
+  message = "No data available",
+  height = 200,
+  icon,
+  className,
+}: ChartEmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center gap-3 rounded-lg",
+        "text-center text-[var(--color-text-muted)]",
+        className
+      )}
+      style={{ height }}
+      aria-label={message}
+    >
+      {icon ?? <DefaultIcon />}
+      <p className="text-sm">{message}</p>
+    </div>
+  );
+}

--- a/src/charts/shared/ChartErrorBoundary.tsx
+++ b/src/charts/shared/ChartErrorBoundary.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  children: React.ReactNode;
+  chartTitle?: string;
+  onRetry?: () => void;
+  className?: string;
+}
+
+interface State {
+  hasError: boolean;
+  message: string;
+}
+
+export class ChartErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, message: "" };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, message: error.message };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    if (process.env.NODE_ENV !== "production") {
+      console.error("[ChartErrorBoundary]", error, info.componentStack);
+    }
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, message: "" });
+    this.props.onRetry?.();
+  };
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+
+    const { chartTitle = "Chart", className } = this.props;
+
+    return (
+      <div
+        role="alert"
+        className={cn(
+          "flex flex-col items-center justify-center gap-3 rounded-lg border p-6 text-center",
+          "border-[var(--color-border-primary)] bg-[var(--color-bg-secondary)]",
+          className
+        )}
+      >
+        <svg
+          className="h-8 w-8 text-amber-500"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+          />
+        </svg>
+        <div>
+          <p className="text-sm font-medium text-[var(--color-text-primary)]">
+            {chartTitle} unavailable
+          </p>
+          <p className="mt-0.5 text-xs text-[var(--color-text-muted)]">
+            An error occurred while rendering this chart.
+          </p>
+        </div>
+        {this.props.onRetry && (
+          <button
+            onClick={this.handleRetry}
+            className="mt-1 rounded-md px-3 py-1.5 text-xs font-medium transition-colors bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]"
+          >
+            Retry
+          </button>
+        )}
+      </div>
+    );
+  }
+}

--- a/src/charts/shared/ChartSkeleton.tsx
+++ b/src/charts/shared/ChartSkeleton.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+interface ChartSkeletonProps {
+  height?: number;
+  className?: string;
+}
+
+export function ChartSkeleton({ height = 300, className }: ChartSkeletonProps) {
+  return (
+    <div
+      role="status"
+      aria-label="Loading chart"
+      className={cn("w-full animate-pulse rounded-lg", className)}
+      style={{ height }}
+    >
+      <span className="sr-only">Loading chart…</span>
+      <div className="flex h-full flex-col gap-2 p-3">
+        {/* Y-axis + bars area */}
+        <div className="flex flex-1 gap-2">
+          <div className="w-10 rounded bg-[var(--color-bg-tertiary)]" />
+          <div className="flex flex-1 flex-col justify-between gap-1">
+            {[0.8, 0.5, 0.65, 0.4, 0.7].map((opacity, i) => (
+              <div
+                key={i}
+                className="rounded bg-[var(--color-bg-tertiary)]"
+                style={{ flex: 1, opacity }}
+              />
+            ))}
+          </div>
+        </div>
+        {/* X-axis label row */}
+        <div className="flex gap-4 pl-12">
+          {[40, 32, 48, 36, 44].map((w, i) => (
+            <div
+              key={i}
+              className="h-2 rounded bg-[var(--color-bg-tertiary)]"
+              style={{ width: w }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/charts/shared/ChartTooltip.tsx
+++ b/src/charts/shared/ChartTooltip.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+interface TooltipEntry {
+  name?: string;
+  value?: number | string;
+  color?: string;
+  dataKey?: string;
+}
+
+interface ChartTooltipProps {
+  active?: boolean;
+  payload?: TooltipEntry[];
+  label?: string;
+  formatter?: (value: number | string, name?: string) => [string, string] | string;
+  labelFormatter?: (label: string) => string;
+  className?: string;
+}
+
+export function ChartTooltip({
+  active,
+  payload,
+  label,
+  formatter,
+  labelFormatter,
+  className,
+}: ChartTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null;
+
+  const displayLabel = label && labelFormatter ? labelFormatter(label) : label;
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border px-3 py-2 shadow-xl text-xs",
+        "bg-[var(--color-bg-secondary)] border-[var(--color-border-primary)]",
+        className
+      )}
+    >
+      {displayLabel && (
+        <p className="mb-1.5 text-[var(--color-text-muted)]">{displayLabel}</p>
+      )}
+      <div className="space-y-1">
+        {payload.map((entry, i) => {
+          const raw = entry.value ?? 0;
+          let displayValue: string;
+          let displayName: string = entry.name ?? entry.dataKey ?? "";
+
+          if (formatter) {
+            const result = formatter(raw, entry.name);
+            if (Array.isArray(result)) {
+              [displayValue, displayName] = result;
+            } else {
+              displayValue = result;
+            }
+          } else {
+            displayValue = typeof raw === "number" ? raw.toLocaleString() : String(raw);
+          }
+
+          return (
+            <div key={i} className="flex items-center justify-between gap-4">
+              <span className="flex items-center gap-1.5 text-[var(--color-text-secondary)]">
+                {entry.color && (
+                  <span
+                    className="inline-block h-2 w-2 rounded-full flex-shrink-0"
+                    style={{ backgroundColor: entry.color }}
+                    aria-hidden="true"
+                  />
+                )}
+                {displayName}
+              </span>
+              <span className="font-semibold text-[var(--color-text-primary)]">
+                {displayValue}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/charts/shared/ChartWrapper.tsx
+++ b/src/charts/shared/ChartWrapper.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+import { ChartSkeleton } from "./ChartSkeleton";
+import { ChartErrorBoundary } from "./ChartErrorBoundary";
+import { ChartEmptyState } from "./ChartEmptyState";
+
+interface ChartWrapperProps {
+  children: React.ReactNode;
+  title?: string;
+  description?: string;
+  isLoading?: boolean;
+  isEmpty?: boolean;
+  error?: Error | null;
+  height?: number;
+  emptyMessage?: string;
+  onRetry?: () => void;
+  className?: string;
+}
+
+export function ChartWrapper({
+  children,
+  title,
+  description,
+  isLoading = false,
+  isEmpty = false,
+  error = null,
+  height = 300,
+  emptyMessage = "No data available",
+  onRetry,
+  className,
+}: ChartWrapperProps) {
+  const ariaLabel = [title, description].filter(Boolean).join(": ") || "Chart";
+
+  if (isLoading) {
+    return <ChartSkeleton height={height} className={className} />;
+  }
+
+  if (isEmpty) {
+    return (
+      <ChartEmptyState
+        message={emptyMessage}
+        height={height}
+        className={className}
+      />
+    );
+  }
+
+  return (
+    <ChartErrorBoundary
+      chartTitle={title}
+      onRetry={onRetry}
+      className={className}
+    >
+      <div
+        role="img"
+        aria-label={ariaLabel}
+        className={cn("w-full", className)}
+      >
+        {children}
+        {description && (
+          <span className="sr-only">{description}</span>
+        )}
+      </div>
+    </ChartErrorBoundary>
+  );
+}

--- a/src/charts/shared/index.ts
+++ b/src/charts/shared/index.ts
@@ -1,0 +1,5 @@
+export { ChartTooltip } from "./ChartTooltip";
+export { ChartSkeleton } from "./ChartSkeleton";
+export { ChartErrorBoundary } from "./ChartErrorBoundary";
+export { ChartEmptyState } from "./ChartEmptyState";
+export { ChartWrapper } from "./ChartWrapper";

--- a/src/components/optimized/LazyComponents.tsx
+++ b/src/components/optimized/LazyComponents.tsx
@@ -90,6 +90,22 @@ export const LazyAPYChart = dynamic(
   }
 );
 
+export const LazyNetworkDiagram = dynamic(
+  () => import("@/charts").then((mod) => ({ default: mod.NetworkDiagram })),
+  {
+    loading: () => <LoadingFallback />,
+    ssr: false,
+  }
+);
+
+export const LazyStatisticsBar = dynamic(
+  () => import("@/charts").then((mod) => ({ default: mod.StatisticsBar })),
+  {
+    loading: () => <LoadingFallback />,
+    ssr: false,
+  }
+);
+
 /**
  * Lazy-loaded Modal components.
  * Modals are only loaded when opened.

--- a/src/hooks/useChartTheme.ts
+++ b/src/hooks/useChartTheme.ts
@@ -1,0 +1,61 @@
+import { useMemo } from "react";
+import { useTheme } from "@/contexts/ThemeContext";
+
+export const CHART_COLORS = [
+  "#6366f1", // indigo   — primary brand
+  "#10b981", // emerald  — success / rewards
+  "#a855f7", // purple   — secondary accent
+  "#f59e0b", // amber    — warning
+  "#ef4444", // red      — danger
+  "#3b82f6", // blue     — info
+  "#f43f5e", // rose     — secondary danger
+  "#06b6d4", // cyan     — tertiary accent
+] as const;
+
+export interface ChartTheme {
+  gridStroke: string;
+  axisTickFill: string;
+  axisLineStroke: string;
+  tooltipBg: string;
+  tooltipBorder: string;
+  tooltipTextColor: string;
+  tooltipLabelColor: string;
+  referenceLineColor: string;
+  palette: readonly string[];
+  isDark: boolean;
+}
+
+export function useChartTheme(): ChartTheme {
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
+
+  return useMemo<ChartTheme>(
+    () =>
+      isDark
+        ? {
+            gridStroke: "rgba(148, 163, 184, 0.1)",
+            axisTickFill: "rgba(255, 255, 255, 0.5)",
+            axisLineStroke: "rgba(255, 255, 255, 0.1)",
+            tooltipBg: "rgba(17, 24, 39, 0.95)",
+            tooltipBorder: "rgba(255, 255, 255, 0.1)",
+            tooltipTextColor: "rgba(255, 255, 255, 0.9)",
+            tooltipLabelColor: "rgba(255, 255, 255, 0.6)",
+            referenceLineColor: "rgba(255, 255, 255, 0.3)",
+            palette: CHART_COLORS,
+            isDark: true,
+          }
+        : {
+            gridStroke: "rgba(100, 116, 139, 0.15)",
+            axisTickFill: "#64748b",
+            axisLineStroke: "#cbd5e1",
+            tooltipBg: "#ffffff",
+            tooltipBorder: "#cbd5e1",
+            tooltipTextColor: "#0f172a",
+            tooltipLabelColor: "#475569",
+            referenceLineColor: "rgba(100, 116, 139, 0.4)",
+            palette: CHART_COLORS,
+            isDark: false,
+          },
+    [isDark]
+  );
+}

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -40,6 +40,8 @@ export enum ChartType {
   BAR = "bar",
   COMPOSED = "composed",
   PIE = "pie",
+  NETWORK = "network",
+  STATISTICS = "statistics",
 }
 
 /**

--- a/src/utils/chartExport.ts
+++ b/src/utils/chartExport.ts
@@ -1,0 +1,97 @@
+import type { ExportConfig, TimeSeriesDataPoint } from "@/types/analytics";
+
+function downloadFile(content: string, filename: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url  = URL.createObjectURL(blob);
+  const a    = document.createElement("a");
+  a.href     = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function filterFields<T extends Record<string, unknown>>(
+  data: T[],
+  fields?: string[]
+): Record<string, unknown>[] {
+  if (!fields || fields.length === 0) return data;
+  return data.map((row) =>
+    Object.fromEntries(fields.filter((f) => f in row).map((f) => [f, row[f]]))
+  );
+}
+
+function filterByDateRange<T extends Record<string, unknown>>(
+  data: T[],
+  dateRange?: ExportConfig["dateRange"]
+): T[] {
+  if (!dateRange) return data;
+  return data.filter((row) => {
+    const ts = row.timestamp;
+    if (typeof ts !== "number") return true;
+    return ts >= dateRange.start && ts <= dateRange.end;
+  });
+}
+
+function toCSV(rows: Record<string, unknown>[]): string {
+  if (rows.length === 0) return "";
+  const headers = Object.keys(rows[0]);
+  const escape  = (v: unknown) => {
+    const s = String(v ?? "");
+    return s.includes(",") || s.includes('"') || s.includes("\n")
+      ? `"${s.replace(/"/g, '""')}"`
+      : s;
+  };
+  const lines = [
+    headers.join(","),
+    ...rows.map((row) => headers.map((h) => escape(row[h])).join(",")),
+  ];
+  return lines.join("\n");
+}
+
+/**
+ * Download chart data as a CSV file.
+ */
+export function exportToCSV(
+  data: Record<string, unknown>[],
+  filename = "export.csv",
+  config?: Partial<ExportConfig>
+): void {
+  let rows = filterByDateRange(data, config?.dateRange);
+  rows     = filterFields(rows, config?.fields);
+
+  const meta = config?.includeMetadata
+    ? `# Exported: ${new Date().toISOString()}\n# Rows: ${rows.length}\n`
+    : "";
+
+  downloadFile(meta + toCSV(rows), filename, "text/csv;charset=utf-8;");
+}
+
+/**
+ * Download chart data as a JSON file.
+ */
+export function exportToJSON(
+  data: unknown,
+  filename = "export.json",
+  config?: Partial<ExportConfig>
+): void {
+  const payload = config?.includeMetadata
+    ? { exportedAt: new Date().toISOString(), data }
+    : data;
+
+  downloadFile(JSON.stringify(payload, null, 2), filename, "application/json");
+}
+
+/**
+ * Convenience wrapper for time-series data (always includes date + value).
+ */
+export function exportTimeSeriesCSV(
+  data: TimeSeriesDataPoint[],
+  filename = "timeseries.csv",
+  config?: Partial<ExportConfig>
+): void {
+  const baseFields = ["date", "value", "timestamp"];
+  const extraFields = config?.fields ?? [];
+  const fields = [...new Set([...baseFields, ...extraFields])];
+
+  exportToCSV(data as Record<string, unknown>[], filename, { ...config, fields });
+}

--- a/tests/charts/ChartTooltip.test.tsx
+++ b/tests/charts/ChartTooltip.test.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ChartTooltip } from "@/charts/shared/ChartTooltip";
+
+describe("ChartTooltip", () => {
+  it("renders nothing when inactive", () => {
+    const { container } = render(
+      <ChartTooltip active={false} payload={[{ name: "Value", value: 42 }]} label="Jan" />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing with empty payload", () => {
+    const { container } = render(
+      <ChartTooltip active={true} payload={[]} label="Jan" />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the label", () => {
+    render(
+      <ChartTooltip
+        active={true}
+        payload={[{ name: "Value", value: 100 }]}
+        label="Feb 2025"
+      />
+    );
+    expect(screen.getByText("Feb 2025")).toBeInTheDocument();
+  });
+
+  it("renders a formatted value via formatter", () => {
+    render(
+      <ChartTooltip
+        active={true}
+        payload={[{ name: "Balance", value: 1234.5 }]}
+        label="Mar"
+        formatter={(v) => `$${Number(v).toFixed(2)}`}
+      />
+    );
+    expect(screen.getByText("$1234.50")).toBeInTheDocument();
+  });
+
+  it("renders multiple payload entries", () => {
+    render(
+      <ChartTooltip
+        active={true}
+        payload={[
+          { name: "Deposits", value: 500, color: "#10b981" },
+          { name: "Withdrawals", value: 200, color: "#ef4444" },
+        ]}
+        label="Apr"
+      />
+    );
+    expect(screen.getByText("Deposits")).toBeInTheDocument();
+    expect(screen.getByText("Withdrawals")).toBeInTheDocument();
+  });
+
+  it("applies labelFormatter when provided", () => {
+    render(
+      <ChartTooltip
+        active={true}
+        payload={[{ name: "APY", value: 5.2 }]}
+        label="raw-label"
+        labelFormatter={(l) => `Formatted: ${l}`}
+      />
+    );
+    expect(screen.getByText("Formatted: raw-label")).toBeInTheDocument();
+  });
+
+  it("returns tuple [displayValue, displayName] from formatter", () => {
+    render(
+      <ChartTooltip
+        active={true}
+        payload={[{ name: "Metric", value: 99 }]}
+        label="X"
+        formatter={(v, name) => [`${v}%`, `Renamed ${name}`]}
+      />
+    );
+    expect(screen.getByText("99%")).toBeInTheDocument();
+    expect(screen.getByText("Renamed Metric")).toBeInTheDocument();
+  });
+});

--- a/tests/charts/ChartWrapper.test.tsx
+++ b/tests/charts/ChartWrapper.test.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ChartWrapper } from "@/charts/shared/ChartWrapper";
+
+describe("ChartWrapper", () => {
+  it("renders children normally", () => {
+    render(
+      <ChartWrapper title="My Chart">
+        <div>Chart content</div>
+      </ChartWrapper>
+    );
+    expect(screen.getByText("Chart content")).toBeInTheDocument();
+  });
+
+  it("has role=img and aria-label", () => {
+    render(
+      <ChartWrapper title="Balance" description="Balance over time">
+        <div>content</div>
+      </ChartWrapper>
+    );
+    const region = screen.getByRole("img");
+    expect(region).toHaveAttribute("aria-label", "Balance: Balance over time");
+  });
+
+  it("shows skeleton when isLoading=true", () => {
+    render(
+      <ChartWrapper title="X" isLoading>
+        <div>hidden content</div>
+      </ChartWrapper>
+    );
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.queryByText("hidden content")).not.toBeInTheDocument();
+  });
+
+  it("shows empty state when isEmpty=true", () => {
+    render(
+      <ChartWrapper title="X" isEmpty emptyMessage="No APY data yet">
+        <div>hidden</div>
+      </ChartWrapper>
+    );
+    expect(screen.getByText("No APY data yet")).toBeInTheDocument();
+    expect(screen.queryByText("hidden")).not.toBeInTheDocument();
+  });
+
+  it("shows error boundary fallback when child throws", () => {
+    const consoleError = jest.spyOn(console, "error").mockImplementation(() => {});
+    const ThrowingChild = () => {
+      throw new Error("render error");
+    };
+    render(
+      <ChartWrapper title="Broken Chart">
+        <ThrowingChild />
+      </ChartWrapper>
+    );
+    expect(screen.getByText(/Broken Chart unavailable/i)).toBeInTheDocument();
+    consoleError.mockRestore();
+  });
+
+  it("calls onRetry when retry button is clicked", () => {
+    const consoleError = jest.spyOn(console, "error").mockImplementation(() => {});
+    const onRetry = jest.fn();
+    const ThrowingChild = () => {
+      throw new Error("boom");
+    };
+    render(
+      <ChartWrapper title="Chart" onRetry={onRetry}>
+        <ThrowingChild />
+      </ChartWrapper>
+    );
+    const retryBtn = screen.getByRole("button", { name: /retry/i });
+    fireEvent.click(retryBtn);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    consoleError.mockRestore();
+  });
+
+  it("uses default aria-label when title and description are omitted", () => {
+    render(
+      <ChartWrapper>
+        <div>c</div>
+      </ChartWrapper>
+    );
+    expect(screen.getByRole("img")).toHaveAttribute("aria-label", "Chart");
+  });
+});

--- a/tests/charts/LineChart.test.tsx
+++ b/tests/charts/LineChart.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { LineChart } from "@/charts/LineChart";
+
+// Mock useChartTheme to avoid needing ThemeContext
+jest.mock("@/hooks/useChartTheme", () => ({
+  useChartTheme: () => ({
+    gridStroke: "#ccc",
+    axisTickFill: "#666",
+    axisLineStroke: "#aaa",
+    tooltipBg: "#fff",
+    tooltipBorder: "#ddd",
+    tooltipTextColor: "#000",
+    tooltipLabelColor: "#555",
+    referenceLineColor: "#999",
+    palette: ["#6366f1"],
+    isDark: false,
+  }),
+}));
+
+const sampleData = [
+  { label: "Jan", value: 100 },
+  { label: "Feb", value: 150 },
+  { label: "Mar", value: 120 },
+];
+
+describe("LineChart", () => {
+  it("renders a chart wrapper with role=img", () => {
+    render(<LineChart data={sampleData} title="Test Line Chart" />);
+    expect(screen.getByRole("img")).toBeInTheDocument();
+  });
+
+  it("uses title as aria-label", () => {
+    render(<LineChart data={sampleData} title="Balance Trend" />);
+    expect(screen.getByRole("img")).toHaveAttribute("aria-label", expect.stringContaining("Balance Trend"));
+  });
+
+  it("shows skeleton when isLoading=true", () => {
+    render(<LineChart data={sampleData} isLoading title="Loading chart" />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("shows empty state when data is empty", () => {
+    render(<LineChart data={[]} title="Empty chart" />);
+    expect(screen.getByText(/No data available/i)).toBeInTheDocument();
+  });
+
+  it("renders the ResponsiveContainer when data is present", () => {
+    render(<LineChart data={sampleData} title="Has data" />);
+    expect(screen.getByTestId("responsive-container")).toBeInTheDocument();
+  });
+});

--- a/tests/charts/NetworkDiagram.test.tsx
+++ b/tests/charts/NetworkDiagram.test.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { NetworkDiagram, metricsToNetworkGraph } from "@/charts/NetworkDiagram";
+import type { ProtocolHealthMetric } from "@/services/protocolHealth";
+
+const metrics: ProtocolHealthMetric[] = [
+  {
+    id: "soroban-rpc",
+    label: "Soroban RPC",
+    description: "RPC endpoint",
+    value: "200 OK",
+    status: "operational",
+    latencyMs: 120,
+    checkedAt: "2025-01-01T00:00:00Z",
+  },
+  {
+    id: "horizon",
+    label: "Horizon Indexer",
+    description: "Horizon endpoint",
+    value: "200 OK",
+    status: "degraded",
+    latencyMs: 3200,
+    checkedAt: "2025-01-01T00:00:00Z",
+  },
+  {
+    id: "contract-config",
+    label: "Contract Configuration",
+    description: "Contract IDs",
+    value: "Configured",
+    status: "operational",
+    checkedAt: "2025-01-01T00:00:00Z",
+  },
+  {
+    id: "event-stream",
+    label: "Event Stream",
+    description: "Event stream",
+    value: "Ready",
+    status: "down",
+    checkedAt: "2025-01-01T00:00:00Z",
+  },
+  {
+    id: "transaction-flow",
+    label: "Transaction Flow",
+    description: "Tx flow",
+    value: "Limited",
+    status: "degraded",
+    checkedAt: "2025-01-01T00:00:00Z",
+  },
+];
+
+describe("NetworkDiagram", () => {
+  it("renders an SVG with role=img", () => {
+    render(<NetworkDiagram metrics={metrics} />);
+    expect(screen.getByRole("img")).toBeInTheDocument();
+  });
+
+  it("has a descriptive aria-label", () => {
+    render(<NetworkDiagram metrics={metrics} title="Protocol Network" />);
+    expect(screen.getByRole("img")).toHaveAttribute(
+      "aria-label",
+      expect.stringContaining("Protocol Network")
+    );
+  });
+
+  it("renders a screen-reader text summary with all node labels", () => {
+    render(<NetworkDiagram metrics={metrics} />);
+    const srEl = document.querySelector(".sr-only");
+    expect(srEl?.textContent).toContain("Soroban RPC");
+    expect(srEl?.textContent).toContain("Horizon Indexer");
+    expect(srEl?.textContent).toContain("degraded");
+    expect(srEl?.textContent).toContain("down");
+  });
+
+  it("includes latency in the screen-reader summary when available", () => {
+    render(<NetworkDiagram metrics={metrics} />);
+    const srEl = document.querySelector(".sr-only");
+    expect(srEl?.textContent).toContain("120ms");
+    expect(srEl?.textContent).toContain("3200ms");
+  });
+
+  it("renders without crashing when metrics is empty", () => {
+    render(<NetworkDiagram metrics={[]} />);
+    expect(screen.getByRole("img")).toBeInTheDocument();
+  });
+
+  it("renders SVG element", () => {
+    const { container } = render(<NetworkDiagram metrics={metrics} />);
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+});
+
+describe("metricsToNetworkGraph", () => {
+  it("maps metric status onto default nodes", () => {
+    const { nodes } = metricsToNetworkGraph(metrics);
+    const rpc = nodes.find((n) => n.id === "soroban-rpc");
+    expect(rpc?.status).toBe("operational");
+    expect(rpc?.latencyMs).toBe(120);
+    const horizon = nodes.find((n) => n.id === "horizon");
+    expect(horizon?.status).toBe("degraded");
+  });
+
+  it("returns the default edges", () => {
+    const { edges } = metricsToNetworkGraph(metrics);
+    expect(edges.length).toBeGreaterThan(0);
+    expect(edges.some((e) => e.from === "soroban-rpc")).toBe(true);
+  });
+});

--- a/tests/charts/StatisticsBar.test.tsx
+++ b/tests/charts/StatisticsBar.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { StatisticsBar } from "@/charts/StatisticsBar";
+
+jest.mock("@/hooks/useChartTheme", () => ({
+  useChartTheme: () => ({
+    gridStroke: "#ccc",
+    axisTickFill: "#666",
+    axisLineStroke: "#aaa",
+    tooltipBg: "#fff",
+    tooltipBorder: "#ddd",
+    tooltipTextColor: "#000",
+    tooltipLabelColor: "#555",
+    referenceLineColor: "#999",
+    palette: ["#6366f1"],
+    isDark: false,
+  }),
+}));
+
+describe("StatisticsBar", () => {
+  it("renders with role=img", () => {
+    render(<StatisticsBar min={0} max={100} average={50} />);
+    expect(screen.getByRole("img")).toBeInTheDocument();
+  });
+
+  it("includes min, average, and max in aria-label", () => {
+    render(
+      <StatisticsBar
+        min={10}
+        max={90}
+        average={45}
+        formatter={(v) => `${v}%`}
+      />
+    );
+    const img = screen.getByRole("img");
+    expect(img).toHaveAttribute("aria-label", expect.stringContaining("10%"));
+    expect(img).toHaveAttribute("aria-label", expect.stringContaining("45%"));
+    expect(img).toHaveAttribute("aria-label", expect.stringContaining("90%"));
+  });
+
+  it("includes current value in aria-label when provided", () => {
+    render(
+      <StatisticsBar
+        min={0}
+        max={100}
+        average={50}
+        current={72}
+        formatter={(v) => `${v}`}
+      />
+    );
+    expect(screen.getByRole("img")).toHaveAttribute(
+      "aria-label",
+      expect.stringContaining("72")
+    );
+  });
+
+  it("renders the label text when provided", () => {
+    render(
+      <StatisticsBar min={0} max={100} average={50} label="APY Range" />
+    );
+    expect(screen.getByText("APY Range")).toBeInTheDocument();
+  });
+
+  it("renders an SVG element", () => {
+    const { container } = render(<StatisticsBar min={0} max={100} average={50} />);
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+});

--- a/tests/charts/chartExport.test.ts
+++ b/tests/charts/chartExport.test.ts
@@ -1,0 +1,106 @@
+import { exportToCSV, exportToJSON, exportTimeSeriesCSV } from "@/utils/chartExport";
+
+function getLastBlobContent(): string {
+  const mockBlob = (global.Blob as jest.Mock).mock.calls.at(-1)?.[0]?.[0] ?? "";
+  return mockBlob;
+}
+
+function getLastDownloadFilename(): string {
+  const anchor = document.querySelector("a[download]") as HTMLAnchorElement | null;
+  return anchor?.download ?? "";
+}
+
+beforeEach(() => {
+  // Mock Blob constructor
+  global.Blob = jest.fn((parts: BlobPart[], options?: BlobPropertyBag) => ({
+    size: (parts as string[]).reduce((s, p) => s + p.length, 0),
+    type: options?.type ?? "",
+    text: async () => (parts as string[]).join(""),
+  })) as unknown as typeof Blob;
+
+  // Mock anchor click
+  const clickMock = jest.fn();
+  jest.spyOn(document, "createElement").mockImplementation((tag) => {
+    if (tag === "a") {
+      const a = { href: "", download: "", click: clickMock } as unknown as HTMLAnchorElement;
+      return a;
+    }
+    return document.createElement(tag);
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("exportToCSV", () => {
+  const data = [
+    { date: "2025-01-01", value: 100, extra: "x" },
+    { date: "2025-01-02", value: 200, extra: "y" },
+  ];
+
+  it("calls Blob with CSV content including headers", () => {
+    exportToCSV(data, "test.csv");
+    const content = getLastBlobContent();
+    expect(content).toContain("date,value,extra");
+    expect(content).toContain("2025-01-01");
+    expect(content).toContain("100");
+  });
+
+  it("filters columns when fields option is provided", () => {
+    exportToCSV(data, "test.csv", { fields: ["date", "value"] });
+    const content = getLastBlobContent();
+    expect(content).toContain("date,value");
+    expect(content).not.toContain("extra");
+  });
+
+  it("adds metadata comment when includeMetadata=true", () => {
+    exportToCSV(data, "test.csv", { includeMetadata: true });
+    const content = getLastBlobContent();
+    expect(content).toContain("# Exported:");
+    expect(content).toContain("# Rows: 2");
+  });
+
+  it("escapes commas in cell values", () => {
+    exportToCSV([{ label: "hello, world", value: 1 }], "test.csv");
+    const content = getLastBlobContent();
+    expect(content).toContain('"hello, world"');
+  });
+});
+
+describe("exportToJSON", () => {
+  it("calls Blob with JSON stringified content", () => {
+    exportToJSON({ key: "value" }, "test.json");
+    const content = getLastBlobContent();
+    expect(JSON.parse(content)).toEqual({ key: "value" });
+  });
+
+  it("wraps data in metadata when includeMetadata=true", () => {
+    exportToJSON([1, 2, 3], "test.json", { includeMetadata: true });
+    const content = getLastBlobContent();
+    const parsed = JSON.parse(content);
+    expect(parsed).toHaveProperty("exportedAt");
+    expect(parsed).toHaveProperty("data");
+    expect(parsed.data).toEqual([1, 2, 3]);
+  });
+});
+
+describe("exportTimeSeriesCSV", () => {
+  const tsData = [
+    { timestamp: 1700000000000, date: "2023-11-14", value: 42 },
+    { timestamp: 1700086400000, date: "2023-11-15", value: 55 },
+  ];
+
+  it("always includes date and value columns", () => {
+    exportTimeSeriesCSV(tsData, "ts.csv");
+    const content = getLastBlobContent();
+    expect(content).toContain("date");
+    expect(content).toContain("value");
+  });
+
+  it("merges extra fields from config.fields", () => {
+    exportTimeSeriesCSV(tsData, "ts.csv", { fields: ["timestamp"] });
+    const content = getLastBlobContent();
+    expect(content).toContain("timestamp");
+  });
+});

--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -1,4 +1,36 @@
 import "@testing-library/jest-dom";
+import React from "react";
+
+// ResizeObserver is not available in jsdom — required by Recharts ResponsiveContainer
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+// URL.createObjectURL is not available in jsdom — required by chartExport
+global.URL.createObjectURL = jest.fn(() => "blob:mock-url");
+global.URL.revokeObjectURL = jest.fn();
+
+// Render Recharts ResponsiveContainer at a fixed size so chart children mount
+jest.mock("recharts", () => {
+  const Recharts = jest.requireActual("recharts");
+  return {
+    ...Recharts,
+    ResponsiveContainer: ({
+      children,
+    }: {
+      children: React.ReactNode;
+      width?: number | string;
+      height?: number | string;
+    }) =>
+      React.createElement(
+        "div",
+        { style: { width: 400, height: 300 }, "data-testid": "responsive-container" },
+        children
+      ),
+  };
+});
 
 Object.defineProperty(window, "matchMedia", {
   writable: true,


### PR DESCRIPTION
## Related Issue
Closes #253 

## Screenshot (Visual sample (this was temporary added, but removed))
<img width="1342" height="517" alt="0" src="https://github.com/user-attachments/assets/9b89aaaa-44bf-48ef-8f07-f548bd2f8e4a" />

## Summary
This PR introduces a reusable visualization framework for the dashboard to standardize chart behavior, improve accessibility, and reduce rendering overhead across analytics surfaces.

## Visualization Architecture
- Added shared chart primitives in `src/charts/shared/`:
  - `ChartWrapper`
  - `ChartTooltip`
  - `ChartSkeleton`
  - `ChartEmptyState`
  - `ChartErrorBoundary`
- Refactored core chart components to use the shared wrapper + tooltip pattern:
  - `LineChart`
  - `BarChart`
  - `ComposedChart`
  - `PieChart`
- Added reusable visualizations:
  - `NetworkDiagram`
  - `StatisticsBar`
- Centralized exports in `src/charts/index.ts` for a consistent import surface.
- Added chart theme tokens via `src/hooks/useChartTheme.ts` for axis/grid/tooltip consistency.

## Accessibility Improvements
- Standardized chart-level semantics with `role="img"` + descriptive labels through `ChartWrapper`.
- Improved non-Recharts chart accessibility:
  - `NetworkDiagram`: screen-reader summaries derived from node status/latency.
  - `StatisticsBar`: generated aria label with min/avg/max/current values.
  - `HealthLatencyBars`: `progressbar` semantics and value attributes.
- Added coverage assertions for accessibility behaviors in chart tests.

## Rendering Performance
- Applied `React.memo` to reusable chart components.
- Added lazy-load chart entries in `src/components/optimized/LazyComponents.tsx`.
- Consolidated loading/empty/error handling into shared primitives to reduce duplicated rendering logic.
- Follow-up correctness hardening:
  - Sanitized and uniquified SVG gradient ids in `StatisticsBar`.
  - Uniquified SVG marker ids in `NetworkDiagram` to prevent multi-instance collisions.

## Rendering Benchmarks
- Implementation includes performance-oriented patterns (memoization + lazy loading + shared render states).
- Quantitative before/after benchmark numbers are not included in this PR yet.
- Suggested follow-up metrics:
  - Initial bundle delta for analytics routes
  - Time-to-interactive deltas for chart-heavy views
  - Re-render counts for chart containers under unchanged props

## Testing Summary
Executed:
- `npx jest tests/charts/ --no-coverage`

Results:
- Test suites: 6 passed
- Tests: 40 passed

<img width="553" height="510" alt="1" src="https://github.com/user-attachments/assets/e2962840-582b-446c-bd98-061e4716ab87" />


Added chart-focused tests in `tests/charts/` for:
- `ChartWrapper`
- `ChartTooltip`
- `LineChart`
- `NetworkDiagram`
- `StatisticsBar`
- `chartExport` utilities

## Documentation
- Added `src/charts/VISUALIZATION_GUIDELINES.md` with standards for:
  - chart selection
  - theming
  - loading/empty/error states
  - accessibility
  - performance usage
  - data export conventions

## Scope Notes
In scope and completed:
- Reusable visualization framework
- Theming support
- Accessibility improvements
- Rendering optimization patterns
- Documentation and tests

Additional (beyond strict minimum scope, but useful):
- `chartExport` utility helpers for CSV/JSON downloads.
