### PR TITLE
Add multi-workspace dashboard support

### DIFF
--- a/docs/workspaces/API.md
+++ b/docs/workspaces/API.md
@@ -1,0 +1,55 @@
+# Workspace API
+
+Workspaces are local dashboard environments for isolating layout state,
+preferences, and protocol views. They are intentionally local-only; team
+collaboration, account management, and cloud sync are out of scope.
+
+## Persistence
+
+Workspace state is stored in `localStorage` under `axionvera-workspaces`.
+The persisted object is versioned:
+
+```ts
+interface WorkspaceState {
+  version: 1;
+  activeWorkspaceId: string;
+  workspaces: Workspace[];
+}
+```
+
+Invalid or legacy data is normalized on load. If parsing fails, the store falls
+back to a default workspace.
+
+## Model
+
+Each workspace contains:
+
+- `layout.sidebarOpen`: isolated sidebar state.
+- `layout.defaultView`: the preferred landing view for the workspace.
+- `layout.visibleViews`: enabled protocol views for the workspace.
+- `preferences.theme`: `light`, `dark`, or `system`.
+- `preferences.network`: `testnet`, `mainnet`, or `custom`.
+- `preferences.pinnedWallets`: wallet addresses associated with the workspace.
+
+## React Usage
+
+Wrap the app with `WorkspaceProvider`, then consume `useWorkspace()`:
+
+```tsx
+const {
+  activeWorkspace,
+  createWorkspace,
+  switchWorkspace,
+  updateWorkspace,
+} = useWorkspace();
+```
+
+`WorkspaceSwitcher` is the default UI entry point and is rendered in the
+navbar. It supports switching, creating, and renaming workspaces.
+
+## Migration Notes
+
+Existing users receive a single `Default workspace` on first load. The
+workspace-aware sidebar hook migrates the previous `sidebar-open` localStorage
+value into that default workspace preference when available.
+

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -6,6 +6,7 @@ import { useSidebar } from "@/hooks/useSidebar";
 import { shortenAddress } from "@/utils/contractHelpers";
 import ThemeToggle from "./ThemeToggle";
 import { WalletId, WalletMeta } from "@/types/wallet";
+import { WorkspaceSwitcher } from "@/workspaces";
 
 type NavbarProps = {
   publicKey: string | null;
@@ -179,6 +180,7 @@ export default function Navbar({
         </div>
 
         <div className="flex items-center gap-4">
+          <WorkspaceSwitcher />
           <ThemeToggle />
 
           {/* ── Connected state ─────────────────────────────────────────── */}

--- a/src/components/optimized/LazyComponents.tsx
+++ b/src/components/optimized/LazyComponents.tsx
@@ -5,7 +5,7 @@
  * Improves initial bundle size and load time.
  */
 
-import dynamic from "next/dynamic";
+import dynamic, { type DynamicOptionsLoadingProps } from "next/dynamic";
 import React from "react";
 
 /**
@@ -108,7 +108,7 @@ export const LazyCreateProposalModal = dynamic(
 export function makeLazy<T extends React.ComponentType<any>>(
   importFn: () => Promise<{ default: T }>,
   options?: {
-    loading?: React.ComponentType;
+    loading?: (loadingProps: DynamicOptionsLoadingProps) => JSX.Element | null;
     ssr?: boolean;
   }
 ): React.ComponentType<React.ComponentProps<T>> {

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,7 +1,10 @@
 import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 
+import { useOptionalWorkspace } from '@/workspaces';
+
 type Theme = 'light' | 'dark' | 'system';
 type ResolvedTheme = 'light' | 'dark';
+const LEGACY_THEME_KEY = 'theme-preference';
 
 interface ThemeContextType {
   theme: Theme;
@@ -12,17 +15,35 @@ interface ThemeContextType {
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
+  const workspaceContext = useOptionalWorkspace();
+  const hasWorkspace = Boolean(workspaceContext);
+  const workspaceId = workspaceContext?.activeWorkspace.id;
+  const workspaceTheme = workspaceContext?.activeWorkspace.preferences.theme;
+  const updateWorkspace = workspaceContext?.updateWorkspace;
   const [theme, setThemeState] = useState<Theme>('system');
   const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>('light');
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
-    const savedTheme = localStorage.getItem('theme-preference') as Theme | null;
-    if (savedTheme) {
-      setThemeState(savedTheme);
+    if (hasWorkspace && workspaceId && updateWorkspace) {
+      const savedTheme = localStorage.getItem(LEGACY_THEME_KEY) as Theme | null;
+      if (isTheme(savedTheme)) {
+        setThemeState(savedTheme);
+        updateWorkspace(workspaceId, {
+          preferences: { theme: savedTheme },
+        });
+        localStorage.removeItem(LEGACY_THEME_KEY);
+      } else {
+        setThemeState(workspaceTheme ?? 'system');
+      }
+    } else {
+      const savedTheme = localStorage.getItem(LEGACY_THEME_KEY) as Theme | null;
+      if (isTheme(savedTheme)) {
+        setThemeState(savedTheme);
+      }
     }
     setMounted(true);
-  }, []);
+  }, [hasWorkspace, updateWorkspace, workspaceId, workspaceTheme]);
 
   useEffect(() => {
     if (!mounted) return;
@@ -50,7 +71,13 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   const setTheme = (newTheme: Theme) => {
     setThemeState(newTheme);
-    localStorage.setItem('theme-preference', newTheme);
+    if (workspaceContext) {
+      workspaceContext.updateWorkspace(workspaceContext.activeWorkspace.id, {
+        preferences: { theme: newTheme },
+      });
+    } else {
+      localStorage.setItem(LEGACY_THEME_KEY, newTheme);
+    }
   };
 
   return (
@@ -58,6 +85,10 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       {children}
     </ThemeContext.Provider>
   );
+}
+
+function isTheme(value: unknown): value is Theme {
+  return value === 'light' || value === 'dark' || value === 'system';
 }
 
 export function useTheme() {

--- a/src/hooks/usePerformance.ts
+++ b/src/hooks/usePerformance.ts
@@ -4,7 +4,13 @@
  * React hooks for performance monitoring and optimization.
  */
 
-import { useEffect, useRef, useCallback, useMemo } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type DependencyList,
+} from "react";
 import { performanceMonitor, MetricType } from "@/utils/performance";
 
 /**
@@ -151,9 +157,9 @@ export function useSlowRenderDetection(
 /**
  * Hook for lazy initialization of expensive values.
  */
-export function useLazyMemo<T>(factory: () => T, deps: React.DependencyList): T {
+export function useLazyMemo<T>(factory: () => T, deps: DependencyList): T {
   const valueRef = useRef<T | null>(null);
-  const depsRef = useRef<React.DependencyList | null>(null);
+  const depsRef = useRef<DependencyList | null>(null);
 
   if (
     valueRef.current === null ||
@@ -172,10 +178,10 @@ export function useLazyMemo<T>(factory: () => T, deps: React.DependencyList): T 
  */
 export function useAsyncMemo<T>(
   factory: () => Promise<T>,
-  deps: React.DependencyList,
+  deps: DependencyList,
   initialValue: T
 ): T {
-  const [value, setValue] = React.useState<T>(initialValue);
+  const [value, setValue] = useState<T>(initialValue);
 
   useEffect(() => {
     let cancelled = false;
@@ -194,16 +200,13 @@ export function useAsyncMemo<T>(
   return value;
 }
 
-// Workaround for React import
-const React = require("react");
-
 /**
  * Hook to batch state updates.
  */
 export function useBatchedState<T>(
   initialState: T
 ): [T, (update: Partial<T>) => void, () => void] {
-  const [state, setState] = React.useState<T>(initialState);
+  const [state, setState] = useState<T>(initialState);
   const pendingUpdates = useRef<Partial<T>[]>([]);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -247,9 +250,9 @@ export function useWebWorker<TInput, TOutput>(
   loading: boolean;
   error: Error | null;
 } {
-  const [result, setResult] = React.useState<TOutput | null>(null);
-  const [loading, setLoading] = React.useState(false);
-  const [error, setError] = React.useState<Error | null>(null);
+  const [result, setResult] = useState<TOutput | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
   const workerRef = useRef<Worker | null>(null);
 
   useEffect(() => {

--- a/src/hooks/useSidebar.test.ts
+++ b/src/hooks/useSidebar.test.ts
@@ -1,69 +1,83 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
+import { createElement } from 'react';
+import type { ReactNode } from 'react';
+
+import { WorkspaceProvider, WORKSPACE_STORAGE_KEY, WorkspaceStore } from '@/workspaces';
+
 import { useSidebar } from './useSidebar';
 
-// Mock localStorage
-const localStorageMock = {
-  getItem: jest.fn(),
-  setItem: jest.fn(),
-  removeItem: jest.fn(),
-  clear: jest.fn(),
-};
-Object.defineProperty(window, 'localStorage', {
-  value: localStorageMock,
-});
+function createMemoryStorage(initial: Record<string, string> = {}) {
+  const data = new Map(Object.entries(initial));
+  return {
+    getItem: jest.fn((key: string) => data.get(key) ?? null),
+    setItem: jest.fn((key: string, value: string) => {
+      data.set(key, value);
+    }),
+    removeItem: jest.fn((key: string) => {
+      data.delete(key);
+    }),
+    clear: jest.fn(() => {
+      data.clear();
+    }),
+    read: (key: string) => data.get(key) ?? null,
+  };
+}
 
 describe('useSidebar', () => {
-  beforeEach(() => {
-    localStorageMock.getItem.mockClear();
-    localStorageMock.setItem.mockClear();
-  });
+  function renderSidebarHook(storage = createMemoryStorage()) {
+    Object.defineProperty(window, 'localStorage', {
+      value: storage,
+      configurable: true,
+    });
 
-  it('should default to open state when no saved state exists', () => {
-    localStorageMock.getItem.mockReturnValue(null);
-    
-    const { result } = renderHook(() => useSidebar());
-    
+    const store = new WorkspaceStore(storage);
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(WorkspaceProvider, { store, children });
+
+    return {
+      storage,
+      store,
+      ...renderHook(() => useSidebar(), { wrapper }),
+    };
+  }
+
+  it('defaults to the active workspace sidebar state', () => {
+    const { result } = renderSidebarHook();
+
     expect(result.current.isOpen).toBe(true);
   });
 
-  it('should load saved state from localStorage', async () => {
-    localStorageMock.getItem.mockReturnValue('false');
-    
-    const { result } = renderHook(() => useSidebar());
-    
+  it('migrates the legacy sidebar key into the active workspace', async () => {
+    const storage = createMemoryStorage({ 'sidebar-open': 'false' });
+
+    const { result, store } = renderSidebarHook(storage);
+
     await waitFor(() => expect(result.current.isOpen).toBe(false));
-    expect(localStorageMock.getItem).toHaveBeenCalledWith('sidebar-open');
+    expect(store.getActiveWorkspace().layout.sidebarOpen).toBe(false);
+    expect(storage.removeItem).toHaveBeenCalledWith('sidebar-open');
   });
 
-  it('should save state to localStorage when changed', async () => {
-    localStorageMock.getItem.mockReturnValue('true');
-    
-    const { result } = renderHook(() => useSidebar());
-    
-    await waitFor(() => expect(result.current.isOpen).toBe(true));
+  it('persists toggles in workspace storage', async () => {
+    const { result, storage, store } = renderSidebarHook();
 
     act(() => {
       result.current.toggle();
     });
-    
-    expect(result.current.isOpen).toBe(false);
-    expect(localStorageMock.setItem).toHaveBeenCalledWith('sidebar-open', 'false');
+
+    await waitFor(() => expect(result.current.isOpen).toBe(false));
+    expect(store.getActiveWorkspace().layout.sidebarOpen).toBe(false);
+
+    const persistedState = JSON.parse(storage.read(WORKSPACE_STORAGE_KEY) ?? '{}');
+    expect(persistedState.workspaces[0].layout.sidebarOpen).toBe(false);
+    expect(storage.setItem).toHaveBeenCalledWith(
+      WORKSPACE_STORAGE_KEY,
+      expect.stringContaining('"sidebarOpen":false'),
+    );
   });
 
-  it('should provide toggle, open, and close functions', () => {
-    localStorageMock.getItem.mockReturnValue('true');
-    
-    const { result } = renderHook(() => useSidebar());
-    
-    expect(typeof result.current.toggle).toBe('function');
-    expect(typeof result.current.open).toBe('function');
-    expect(typeof result.current.close).toBe('function');
-  });
-
-  it('should handle open and close functions correctly', async () => {
-    localStorageMock.getItem.mockReturnValue('false');
-    
-    const { result } = renderHook(() => useSidebar());
+  it('provides toggle, open, and close actions', async () => {
+    const storage = createMemoryStorage({ 'sidebar-open': 'false' });
+    const { result } = renderSidebarHook(storage);
 
     await waitFor(() => expect(result.current.isOpen).toBe(false));
 
@@ -71,12 +85,12 @@ describe('useSidebar', () => {
       result.current.open();
     });
     expect(result.current.isOpen).toBe(true);
-    expect(localStorageMock.setItem).toHaveBeenCalledWith('sidebar-open', 'true');
-    
+
     act(() => {
       result.current.close();
     });
     expect(result.current.isOpen).toBe(false);
-    expect(localStorageMock.setItem).toHaveBeenCalledWith('sidebar-open', 'false');
+
+    expect(typeof result.current.toggle).toBe('function');
   });
 });

--- a/src/hooks/useSidebar.ts
+++ b/src/hooks/useSidebar.ts
@@ -1,42 +1,44 @@
-import { useEffect, useState, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
+
+import { useWorkspace } from '@/workspaces';
 
 const SIDEBAR_STATE_KEY = 'sidebar-open';
 
 export function useSidebar() {
-  // We default to true (open) to match expected dashboard behavior and unit tests.
-  // We use a mount ref to prevent hydration mismatches and unnecessary localStorage writes on first load.
-  const [isOpen, setIsOpen] = useState<boolean>(true);
-  const hasMounted = useRef(false);
+  const { activeWorkspace, updateWorkspace } = useWorkspace();
+  const migratedWorkspaceIds = useRef(new Set<string>());
 
-  // Initialize from localStorage after mounting to avoid hydration mismatch
   useEffect(() => {
+    if (migratedWorkspaceIds.current.has(activeWorkspace.id)) return;
+    migratedWorkspaceIds.current.add(activeWorkspace.id);
+
     try {
       const savedState = localStorage.getItem(SIDEBAR_STATE_KEY);
-      if (savedState !== null) {
-        setIsOpen(JSON.parse(savedState));
+      if (savedState === null) return;
+
+      const migratedState = JSON.parse(savedState);
+      if (typeof migratedState === 'boolean') {
+        updateWorkspace(activeWorkspace.id, { layout: { sidebarOpen: migratedState } });
       }
+      localStorage.removeItem(SIDEBAR_STATE_KEY);
     } catch (error) {
       console.warn('Failed to parse sidebar state from localStorage:', error);
     }
-    // Set mounted flag AFTER we've attempted to load from storage
-    hasMounted.current = true;
-  }, []);
+  }, [activeWorkspace.id, updateWorkspace]);
 
-  // Persist state changes after mount
-  useEffect(() => {
-    // Only save if we have finished mounting (to avoid overriding saved state with default during hydration)
-    if (!hasMounted.current) return;
+  const setSidebarOpen = useCallback(
+    (sidebarOpen: boolean) => {
+      updateWorkspace(activeWorkspace.id, { layout: { sidebarOpen } });
+    },
+    [activeWorkspace.id, updateWorkspace],
+  );
 
-    try {
-      localStorage.setItem(SIDEBAR_STATE_KEY, JSON.stringify(isOpen));
-    } catch (error) {
-      console.warn('Failed to save sidebar state to localStorage:', error);
-    }
-  }, [isOpen]);
+  const toggle = useCallback(
+    () => setSidebarOpen(!activeWorkspace.layout.sidebarOpen),
+    [activeWorkspace.layout.sidebarOpen, setSidebarOpen],
+  );
+  const open = useCallback(() => setSidebarOpen(true), [setSidebarOpen]);
+  const close = useCallback(() => setSidebarOpen(false), [setSidebarOpen]);
 
-  const toggle = () => setIsOpen(prev => !prev);
-  const open = () => setIsOpen(true);
-  const close = () => setIsOpen(false);
-
-  return { isOpen, toggle, open, close };
+  return { isOpen: activeWorkspace.layout.sidebarOpen, toggle, open, close };
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -17,6 +17,7 @@ import { initTelemetry } from "@/utils/telemetry";
 import { emit } from "@/observability/diagnostics";
 import { GovernanceProvider } from "@/contexts/GovernanceContext";
 import { OfflineProvider } from "@/pwa/OfflineProvider";
+import { WorkspaceProvider } from "@/workspaces";
 
 
 function AppInner(props: AppProps) {
@@ -39,16 +40,18 @@ function AppInner(props: AppProps) {
     // fontFamily tokens and any CSS that references them directly.
     <div className={`${inter.variable} ${jetbrainsMono.variable}`}>
       <ErrorBoundary>
-        <ThemeProvider>
-          <OfflineProvider>
-            <WalletProvider>
-              <RBACProvider>
-                <ProvidersInner Component={Component} pageProps={pageProps} router={router} />
-              </RBACProvider>
-            </WalletProvider>
-            <Toaster />
-          </OfflineProvider>
-        </ThemeProvider>
+        <WorkspaceProvider>
+          <ThemeProvider>
+            <OfflineProvider>
+              <WalletProvider>
+                <RBACProvider>
+                  <ProvidersInner Component={Component} pageProps={pageProps} />
+                </RBACProvider>
+              </WalletProvider>
+              <Toaster />
+            </OfflineProvider>
+          </ThemeProvider>
+        </WorkspaceProvider>
       </ErrorBoundary>
     </div>
   );
@@ -58,7 +61,7 @@ function AppInner(props: AppProps) {
  * Inner wrapper that has access to the WalletContext, so it can pass
  * `walletAddress` down to GovernanceProvider and VaultProvider.
  */
-function ProvidersInner({ Component, pageProps }: AppProps) {
+function ProvidersInner({ Component, pageProps }: Pick<AppProps, "Component" | "pageProps">) {
   const wallet = useWalletContext();
   return (
     <GovernanceProvider walletAddress={wallet.publicKey}>

--- a/src/permissions/index.ts
+++ b/src/permissions/index.ts
@@ -34,7 +34,6 @@ export {
 // Types
 export type {
   UserRole,
-  Permission,
   RouteAccess,
   UserWithRole,
   PermissionCheckResult,

--- a/src/services/analytics/calculations.ts
+++ b/src/services/analytics/calculations.ts
@@ -8,13 +8,13 @@
 import type {
   TimeSeriesDataPoint,
   PeriodMetrics,
-  TimePeriod,
   VaultPerformance,
   RewardAnalytics,
   FlowAnalytics,
   APYAnalytics,
   ParticipationMetrics,
 } from "@/types/analytics";
+import { TimePeriod } from "@/types/analytics";
 
 /**
  * Calculate basic statistics for a dataset.

--- a/src/services/analytics/filters.ts
+++ b/src/services/analytics/filters.ts
@@ -8,8 +8,8 @@
 import type {
   TimeSeriesDataPoint,
   AnalyticsFilter,
-  TimePeriod,
 } from "@/types/analytics";
+import { TimePeriod } from "@/types/analytics";
 
 /**
  * Get date range for a time period.

--- a/src/services/analytics/index.ts
+++ b/src/services/analytics/index.ts
@@ -9,8 +9,8 @@ import type {
   AnalyticsData,
   AnalyticsFilter,
   TimeSeriesDataPoint,
-  TimePeriod,
 } from "@/types/analytics";
+import { TimePeriod } from "@/types/analytics";
 import {
   calculateVaultPerformance,
   calculateRewardAnalytics,

--- a/src/utils/__tests__/themeBootstrap.test.ts
+++ b/src/utils/__tests__/themeBootstrap.test.ts
@@ -3,6 +3,8 @@ import { themeBootstrapScript } from '../themeBootstrap';
 describe('themeBootstrap', () => {
   it('should export a valid script string', () => {
     expect(typeof themeBootstrapScript).toBe('string');
+    expect(themeBootstrapScript).toContain('localStorage.getItem(\'axionvera-workspaces\')');
+    expect(themeBootstrapScript).toContain('activeWorkspace.preferences.theme');
     expect(themeBootstrapScript).toContain('localStorage.getItem(\'theme-preference\')');
     expect(themeBootstrapScript).toContain('document.documentElement.setAttribute(\'data-theme\', resolvedTheme)');
   });

--- a/src/utils/themeBootstrap.ts
+++ b/src/utils/themeBootstrap.ts
@@ -2,6 +2,18 @@ export const themeBootstrapScript = `
   (function() {
     try {
       var savedTheme = localStorage.getItem('theme-preference');
+      var workspaceState = localStorage.getItem('axionvera-workspaces');
+      if (workspaceState) {
+        try {
+          var parsedWorkspaceState = JSON.parse(workspaceState);
+          var activeWorkspace = parsedWorkspaceState.workspaces && parsedWorkspaceState.workspaces.find(function(workspace) {
+            return workspace.id === parsedWorkspaceState.activeWorkspaceId;
+          });
+          if (activeWorkspace && activeWorkspace.preferences) {
+            savedTheme = activeWorkspace.preferences.theme;
+          }
+        } catch (workspaceError) {}
+      }
       var resolvedTheme;
       if (savedTheme === 'dark' || savedTheme === 'light') {
         resolvedTheme = savedTheme;

--- a/src/workspaces/WorkspaceContext.tsx
+++ b/src/workspaces/WorkspaceContext.tsx
@@ -1,0 +1,78 @@
+import React, {
+  createContext,
+  ReactNode,
+  useContext,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from "react";
+
+import {
+  createWorkspaceStore,
+  getBrowserWorkspaceStorage,
+  WorkspaceStore,
+} from "./store";
+import type { Workspace, WorkspaceSeed, WorkspaceState, WorkspaceUpdate } from "./types";
+
+interface WorkspaceContextValue {
+  state: WorkspaceState;
+  activeWorkspace: Workspace;
+  createWorkspace: (name: string, seed?: WorkspaceSeed) => Workspace;
+  switchWorkspace: (workspaceId: string) => void;
+  updateWorkspace: (workspaceId: string, update: WorkspaceUpdate) => Workspace;
+  deleteWorkspace: (workspaceId: string) => void;
+}
+
+const WorkspaceContext = createContext<WorkspaceContextValue | undefined>(undefined);
+
+interface WorkspaceProviderProps {
+  children: ReactNode;
+  store?: WorkspaceStore;
+}
+
+export function WorkspaceProvider({ children, store }: WorkspaceProviderProps) {
+  const storeRef = useRef<WorkspaceStore>();
+  if (!storeRef.current) {
+    storeRef.current = store ?? createWorkspaceStore(getBrowserWorkspaceStorage());
+  }
+
+  const activeStore = storeRef.current;
+  const state = useSyncExternalStore(
+    activeStore.subscribe,
+    activeStore.getSnapshot,
+    activeStore.getSnapshot,
+  );
+
+  const actions = useMemo(
+    () => ({
+      createWorkspace: activeStore.createWorkspace.bind(activeStore),
+      switchWorkspace: activeStore.switchWorkspace.bind(activeStore),
+      updateWorkspace: activeStore.updateWorkspace.bind(activeStore),
+      deleteWorkspace: activeStore.deleteWorkspace.bind(activeStore),
+    }),
+    [activeStore],
+  );
+
+  const value = useMemo<WorkspaceContextValue>(
+    () => ({
+      state,
+      activeWorkspace: activeStore.getActiveWorkspace(),
+      ...actions,
+    }),
+    [actions, activeStore, state],
+  );
+
+  return <WorkspaceContext.Provider value={value}>{children}</WorkspaceContext.Provider>;
+}
+
+export function useOptionalWorkspace() {
+  return useContext(WorkspaceContext);
+}
+
+export function useWorkspace() {
+  const context = useOptionalWorkspace();
+  if (!context) {
+    throw new Error("useWorkspace must be used within a WorkspaceProvider");
+  }
+  return context;
+}

--- a/src/workspaces/WorkspaceSwitcher.tsx
+++ b/src/workspaces/WorkspaceSwitcher.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useRef, useState } from "react";
+
+import { useWorkspace } from "./WorkspaceContext";
+
+export function WorkspaceSwitcher() {
+  const {
+    state,
+    activeWorkspace,
+    createWorkspace,
+    switchWorkspace,
+    updateWorkspace,
+  } = useWorkspace();
+  const [isOpen, setIsOpen] = useState(false);
+  const [newWorkspaceName, setNewWorkspaceName] = useState("");
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    function handlePointerDown(event: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+        document.getElementById("workspace-switcher-button")?.focus();
+      }
+    }
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
+
+  function handleCreateWorkspace() {
+    const workspace = createWorkspace(newWorkspaceName);
+    setNewWorkspaceName("");
+    setIsOpen(false);
+    switchWorkspace(workspace.id);
+  }
+
+  function handleRenameActiveWorkspace() {
+    const nextName = window.prompt("Workspace name", activeWorkspace.name);
+    if (!nextName) return;
+    updateWorkspace(activeWorkspace.id, { name: nextName });
+  }
+
+  return (
+    <div className="relative" ref={menuRef}>
+      <button
+        id="workspace-switcher-button"
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        aria-label={`Switch workspace. Active workspace: ${activeWorkspace.name}`}
+        onClick={() => setIsOpen((value) => !value)}
+        className="flex h-10 min-w-0 items-center gap-2 rounded-xl border border-slate-200 bg-slate-100/30 px-3 py-2 text-left text-xs text-slate-700 transition hover:bg-slate-200/50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-slate-800 dark:bg-slate-900/30 dark:text-slate-200 dark:hover:bg-slate-900/60"
+      >
+        <span className="h-2 w-2 shrink-0 rounded-full bg-axion-500" aria-hidden="true" />
+        <span className="hidden min-w-0 max-w-[14rem] truncate sm:inline">{activeWorkspace.name}</span>
+        <svg
+          className={`h-3 w-3 shrink-0 transition-transform ${isOpen ? "rotate-180" : ""}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div
+          role="menu"
+          aria-labelledby="workspace-switcher-button"
+          className="absolute right-0 z-50 mt-2 w-[min(20rem,calc(100vw-2rem))] origin-top-right rounded-2xl border border-slate-200 bg-white shadow-xl ring-1 ring-black/5 dark:border-slate-800 dark:bg-slate-950 dark:ring-white/5"
+        >
+          <div className="border-b border-slate-100 px-4 py-3 dark:border-slate-800">
+            <p className="text-xs font-medium uppercase tracking-wider text-slate-400">
+              Workspaces
+            </p>
+            <p className="mt-1 truncate text-sm font-semibold text-slate-900 dark:text-white">
+              {activeWorkspace.name}
+            </p>
+          </div>
+
+          <div className="max-h-64 space-y-1 overflow-y-auto px-2 py-2">
+            {state.workspaces.map((workspace) => {
+              const isActive = workspace.id === activeWorkspace.id;
+              return (
+                <button
+                  key={workspace.id}
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={isActive}
+                  onClick={() => {
+                    switchWorkspace(workspace.id);
+                    setIsOpen(false);
+                  }}
+                  className={`flex w-full items-center justify-between gap-3 rounded-xl px-3 py-2 text-left text-sm transition ${
+                    isActive
+                      ? "bg-axion-50 text-axion-700 dark:bg-axion-500/10 dark:text-axion-300"
+                      : "text-slate-700 hover:bg-slate-100 dark:text-slate-200 dark:hover:bg-slate-900/60"
+                  }`}
+                >
+                  <span className="min-w-0 truncate">{workspace.name}</span>
+                  {isActive && <span className="text-xs font-medium">Active</span>}
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="border-t border-slate-100 px-3 py-3 dark:border-slate-800">
+            <label
+              htmlFor="new-workspace-name"
+              className="mb-1 block text-xs font-medium text-slate-500 dark:text-slate-400"
+            >
+              New workspace
+            </label>
+            <div className="flex gap-2">
+              <input
+                id="new-workspace-name"
+                value={newWorkspaceName}
+                onChange={(event) => setNewWorkspaceName(event.target.value)}
+                placeholder="Trading, ops, research"
+                className="min-w-0 flex-1 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-axion-400 focus:ring-2 focus:ring-axion-500/20 dark:border-slate-800 dark:bg-slate-950 dark:text-white"
+              />
+              <button
+                type="button"
+                onClick={handleCreateWorkspace}
+                className="rounded-xl bg-axion-500 px-3 py-2 text-sm font-medium text-white transition hover:bg-axion-400"
+              >
+                Create
+              </button>
+            </div>
+            <button
+              type="button"
+              onClick={handleRenameActiveWorkspace}
+              className="mt-2 text-xs font-medium text-slate-500 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+            >
+              Rename active workspace
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/workspaces/index.ts
+++ b/src/workspaces/index.ts
@@ -1,0 +1,5 @@
+export * from "./WorkspaceContext";
+export * from "./WorkspaceSwitcher";
+export * from "./store";
+export * from "./types";
+

--- a/src/workspaces/store.ts
+++ b/src/workspaces/store.ts
@@ -1,0 +1,348 @@
+import type {
+  Workspace,
+  WorkspaceLayoutSettings,
+  WorkspacePreferences,
+  WorkspaceSeed,
+  WorkspaceState,
+  WorkspaceUpdate,
+  WorkspaceView,
+} from "./types";
+
+export const WORKSPACE_STORAGE_KEY = "axionvera-workspaces";
+export const DEFAULT_WORKSPACE_ID = "default";
+const MAX_WORKSPACES = 12;
+
+const DEFAULT_VISIBLE_VIEWS: WorkspaceView[] = [
+  "vault",
+  "analytics",
+  "governance",
+  "monitoring",
+];
+
+const DEFAULT_LAYOUT: WorkspaceLayoutSettings = {
+  sidebarOpen: true,
+  defaultView: "vault",
+  visibleViews: DEFAULT_VISIBLE_VIEWS,
+};
+
+const DEFAULT_PREFERENCES: WorkspacePreferences = {
+  theme: "system",
+  network: "testnet",
+  pinnedWallets: [],
+};
+
+const WORKSPACE_THEMES: WorkspacePreferences["theme"][] = ["light", "dark", "system"];
+const WORKSPACE_NETWORKS: WorkspacePreferences["network"][] = ["testnet", "mainnet", "custom"];
+
+export function createDefaultWorkspace(now = new Date().toISOString()): Workspace {
+  return {
+    id: DEFAULT_WORKSPACE_ID,
+    name: "Default workspace",
+    createdAt: now,
+    updatedAt: now,
+    layout: { ...DEFAULT_LAYOUT, visibleViews: [...DEFAULT_VISIBLE_VIEWS] },
+    preferences: { ...DEFAULT_PREFERENCES, pinnedWallets: [] },
+  };
+}
+
+export function createInitialWorkspaceState(now = new Date().toISOString()): WorkspaceState {
+  return {
+    version: 1,
+    activeWorkspaceId: DEFAULT_WORKSPACE_ID,
+    workspaces: [createDefaultWorkspace(now)],
+  };
+}
+
+type WorkspaceStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+function canUseStorage(storage?: WorkspaceStorage): storage is WorkspaceStorage {
+  return Boolean(storage);
+}
+
+function normalizeWorkspace(input: Partial<Workspace>, fallback: Workspace): Workspace {
+  const now = new Date().toISOString();
+  const layout = input.layout as Partial<WorkspaceLayoutSettings> | undefined;
+  const preferences = input.preferences as Partial<WorkspacePreferences> | undefined;
+
+  return {
+    id: typeof input.id === "string" && input.id.trim() ? input.id : fallback.id,
+    name: typeof input.name === "string" && input.name.trim() ? input.name : fallback.name,
+    createdAt: typeof input.createdAt === "string" ? input.createdAt : fallback.createdAt,
+    updatedAt: typeof input.updatedAt === "string" ? input.updatedAt : now,
+    layout: {
+      sidebarOpen: typeof layout?.sidebarOpen === "boolean" ? layout.sidebarOpen : fallback.layout.sidebarOpen,
+      defaultView: isWorkspaceView(layout?.defaultView) ? layout.defaultView : fallback.layout.defaultView,
+      visibleViews: normalizeVisibleViews(layout?.visibleViews, fallback.layout.visibleViews),
+    },
+    preferences: {
+      theme: isWorkspaceTheme(preferences?.theme) ? preferences.theme : fallback.preferences.theme,
+      network: isWorkspaceNetwork(preferences?.network) ? preferences.network : fallback.preferences.network,
+      pinnedWallets: normalizePinnedWallets(preferences?.pinnedWallets),
+    },
+  };
+}
+
+export function normalizeWorkspaceState(input: unknown): WorkspaceState {
+  const fallback = createInitialWorkspaceState();
+  if (!input || typeof input !== "object") return fallback;
+
+  const candidate = input as Partial<WorkspaceState>;
+  if (!Array.isArray(candidate.workspaces) || candidate.workspaces.length === 0) {
+    return fallback;
+  }
+
+  const ids = new Set<string>();
+  const workspaces = candidate.workspaces
+    .slice(0, MAX_WORKSPACES)
+    .map((workspace, index) =>
+      normalizeWorkspace(
+        workspace && typeof workspace === "object" ? workspace : {},
+        createFallbackWorkspace(index),
+      ),
+    )
+    .filter((workspace) => {
+      if (ids.has(workspace.id)) return false;
+      ids.add(workspace.id);
+      return true;
+    });
+
+  if (workspaces.length === 0) return fallback;
+
+  const activeWorkspaceId = workspaces.some((workspace) => workspace.id === candidate.activeWorkspaceId)
+    ? candidate.activeWorkspaceId!
+    : workspaces[0].id;
+
+  return {
+    version: 1,
+    activeWorkspaceId,
+    workspaces,
+  };
+}
+
+export class WorkspaceStore {
+  private state: WorkspaceState;
+  private readonly listeners = new Set<() => void>();
+  private readonly storage?: WorkspaceStorage;
+  private readonly storageKey: string;
+
+  constructor(storage?: WorkspaceStorage, storageKey = WORKSPACE_STORAGE_KEY) {
+    this.storage = storage;
+    this.storageKey = storageKey;
+    this.state = this.load();
+    this.subscribe = this.subscribe.bind(this);
+    this.getSnapshot = this.getSnapshot.bind(this);
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  getSnapshot(): WorkspaceState {
+    return this.state;
+  }
+
+  getActiveWorkspace(): Workspace {
+    return (
+      this.state.workspaces.find((workspace) => workspace.id === this.state.activeWorkspaceId) ??
+      this.state.workspaces[0]
+    );
+  }
+
+  createWorkspace(name: string, seed?: WorkspaceSeed): Workspace {
+    if (this.state.workspaces.length >= MAX_WORKSPACES) {
+      throw new Error(`Workspace limit of ${MAX_WORKSPACES} reached`);
+    }
+
+    const now = new Date().toISOString();
+    const base = this.getActiveWorkspace();
+    const workspace: Workspace = {
+      id: createUniqueWorkspaceId(seed?.id ?? name, now, this.state.workspaces),
+      name: sanitizeWorkspaceName(seed?.name ?? name),
+      createdAt: seed?.createdAt ?? now,
+      updatedAt: seed?.updatedAt ?? now,
+      layout: {
+        ...base.layout,
+        ...(seed?.layout ?? {}),
+        visibleViews: [...(seed?.layout?.visibleViews ?? base.layout.visibleViews)],
+      },
+      preferences: {
+        ...base.preferences,
+        ...(seed?.preferences ?? {}),
+        pinnedWallets: [...(seed?.preferences?.pinnedWallets ?? base.preferences.pinnedWallets)],
+      },
+    };
+
+    this.setState({
+      ...this.state,
+      activeWorkspaceId: workspace.id,
+      workspaces: [...this.state.workspaces, workspace],
+    });
+    return workspace;
+  }
+
+  switchWorkspace(workspaceId: string): void {
+    if (!this.state.workspaces.some((workspace) => workspace.id === workspaceId)) {
+      throw new Error(`Workspace "${workspaceId}" does not exist`);
+    }
+    if (this.state.activeWorkspaceId === workspaceId) return;
+    this.setState({ ...this.state, activeWorkspaceId: workspaceId });
+  }
+
+  updateWorkspace(workspaceId: string, update: WorkspaceUpdate): Workspace {
+    let updatedWorkspace: Workspace | null = null;
+    const now = new Date().toISOString();
+    const workspaces = this.state.workspaces.map((workspace) => {
+      if (workspace.id !== workspaceId) return workspace;
+      updatedWorkspace = {
+        ...workspace,
+        name: update.name ? sanitizeWorkspaceName(update.name) : workspace.name,
+        updatedAt: now,
+        layout: {
+          ...workspace.layout,
+          ...(update.layout ?? {}),
+          visibleViews: update.layout?.visibleViews
+            ? [...update.layout.visibleViews]
+            : [...workspace.layout.visibleViews],
+        },
+        preferences: {
+          ...workspace.preferences,
+          ...(update.preferences ?? {}),
+          pinnedWallets: update.preferences?.pinnedWallets
+            ? [...update.preferences.pinnedWallets]
+            : [...workspace.preferences.pinnedWallets],
+        },
+      };
+      return updatedWorkspace;
+    });
+
+    if (!updatedWorkspace) {
+      throw new Error(`Workspace "${workspaceId}" does not exist`);
+    }
+
+    this.setState({ ...this.state, workspaces });
+    return updatedWorkspace;
+  }
+
+  deleteWorkspace(workspaceId: string): void {
+    if (this.state.workspaces.length === 1) {
+      throw new Error("Cannot delete the final workspace");
+    }
+
+    const workspaces = this.state.workspaces.filter((workspace) => workspace.id !== workspaceId);
+    if (workspaces.length === this.state.workspaces.length) {
+      throw new Error(`Workspace "${workspaceId}" does not exist`);
+    }
+
+    const activeWorkspaceId =
+      this.state.activeWorkspaceId === workspaceId ? workspaces[0].id : this.state.activeWorkspaceId;
+    this.setState({ ...this.state, activeWorkspaceId, workspaces });
+  }
+
+  private load(): WorkspaceState {
+    if (!canUseStorage(this.storage)) return createInitialWorkspaceState();
+
+    const raw = this.storage.getItem(this.storageKey);
+    if (!raw) return createInitialWorkspaceState();
+
+    try {
+      return normalizeWorkspaceState(JSON.parse(raw));
+    } catch {
+      this.storage.removeItem(this.storageKey);
+      return createInitialWorkspaceState();
+    }
+  }
+
+  private setState(nextState: WorkspaceState): void {
+    this.state = normalizeWorkspaceState(nextState);
+    this.persist();
+    this.listeners.forEach((listener) => listener());
+  }
+
+  private persist(): void {
+    if (!canUseStorage(this.storage)) return;
+    this.storage.setItem(this.storageKey, JSON.stringify(this.state));
+  }
+}
+
+export function createWorkspaceStore(storage?: WorkspaceStorage): WorkspaceStore {
+  return new WorkspaceStore(storage);
+}
+
+export function getBrowserWorkspaceStorage(): WorkspaceStorage | undefined {
+  if (typeof window === "undefined") return undefined;
+  return window.localStorage;
+}
+
+function sanitizeWorkspaceName(name: string): string {
+  const trimmed = name.trim();
+  return trimmed || "Untitled workspace";
+}
+
+function createFallbackWorkspace(index: number): Workspace {
+  if (index === 0) return createDefaultWorkspace();
+
+  const now = new Date().toISOString();
+  return {
+    ...createDefaultWorkspace(now),
+    id: `workspace-${index + 1}`,
+    name: `Workspace ${index + 1}`,
+  };
+}
+
+function isWorkspaceView(value: unknown): value is WorkspaceView {
+  return DEFAULT_VISIBLE_VIEWS.includes(value as WorkspaceView);
+}
+
+function isWorkspaceTheme(value: unknown): value is WorkspacePreferences["theme"] {
+  return WORKSPACE_THEMES.includes(value as WorkspacePreferences["theme"]);
+}
+
+function isWorkspaceNetwork(value: unknown): value is WorkspacePreferences["network"] {
+  return WORKSPACE_NETWORKS.includes(value as WorkspacePreferences["network"]);
+}
+
+function normalizeVisibleViews(
+  views: unknown,
+  fallback: WorkspaceView[],
+): WorkspaceView[] {
+  if (!Array.isArray(views)) return [...fallback];
+
+  const validViews = views.filter(isWorkspaceView);
+  return validViews.length > 0 ? Array.from(new Set(validViews)) : [...fallback];
+}
+
+function normalizePinnedWallets(wallets: unknown): string[] {
+  if (!Array.isArray(wallets)) return [];
+
+  return Array.from(
+    new Set(
+      wallets
+        .filter((wallet): wallet is string => typeof wallet === "string" && wallet.trim().length > 0)
+        .map((wallet) => wallet.trim()),
+    ),
+  );
+}
+
+function createUniqueWorkspaceId(name: string, now: string, workspaces: Workspace[]): string {
+  const baseId = createWorkspaceId(name, now);
+  const existingIds = new Set(workspaces.map((workspace) => workspace.id));
+  if (!existingIds.has(baseId)) return baseId;
+
+  let index = 2;
+  let candidateId = `${baseId}-${index}`;
+  while (existingIds.has(candidateId)) {
+    index += 1;
+    candidateId = `${baseId}-${index}`;
+  }
+  return candidateId;
+}
+
+function createWorkspaceId(name: string, now: string): string {
+  const slug = sanitizeWorkspaceName(name)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "")
+    .slice(0, 32);
+  return `workspace-${slug || "untitled"}-${Date.parse(now).toString(36)}`;
+}

--- a/src/workspaces/types.ts
+++ b/src/workspaces/types.ts
@@ -1,0 +1,44 @@
+export type WorkspaceView = "vault" | "analytics" | "governance" | "monitoring";
+
+export type WorkspaceThemePreference = "light" | "dark" | "system";
+
+export interface WorkspaceLayoutSettings {
+  sidebarOpen: boolean;
+  defaultView: WorkspaceView;
+  visibleViews: WorkspaceView[];
+}
+
+export interface WorkspacePreferences {
+  theme: WorkspaceThemePreference;
+  network: "testnet" | "mainnet" | "custom";
+  pinnedWallets: string[];
+}
+
+export interface Workspace {
+  id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+  layout: WorkspaceLayoutSettings;
+  preferences: WorkspacePreferences;
+}
+
+export interface WorkspaceState {
+  version: 1;
+  activeWorkspaceId: string;
+  workspaces: Workspace[];
+}
+
+export type WorkspaceSeed = Partial<
+  Pick<Workspace, "id" | "name" | "createdAt" | "updatedAt"> & {
+    layout: Partial<WorkspaceLayoutSettings>;
+    preferences: Partial<WorkspacePreferences>;
+  }
+>;
+
+export type WorkspaceUpdate = Partial<
+  Pick<Workspace, "name"> & {
+    layout: Partial<WorkspaceLayoutSettings>;
+    preferences: Partial<WorkspacePreferences>;
+  }
+>;

--- a/tests/components/Navbar.test.tsx
+++ b/tests/components/Navbar.test.tsx
@@ -4,6 +4,7 @@ import type { ReactNode, ReactElement } from "react";
 
 import Navbar from "@/components/Navbar";
 import { ThemeProvider } from "@/contexts/ThemeContext";
+import { WorkspaceProvider, WorkspaceStore } from "@/workspaces";
 
 jest.mock("next/link", () => ({
   __esModule: true,
@@ -16,7 +17,17 @@ jest.mock("next/link", () => ({
 
 jest.mock("next/image", () => ({
   __esModule: true,
-  default: ({ src, alt, ...props }: { src: string; alt: string; [k: string]: unknown }) => (
+  default: ({
+    src,
+    alt,
+    priority: _priority,
+    ...props
+  }: {
+    src: string;
+    alt: string;
+    priority?: boolean;
+    [k: string]: unknown;
+  }) => (
     // eslint-disable-next-line @next/next/no-img-element
     <img src={src} alt={alt} {...(props as object)} />
   ),
@@ -44,7 +55,18 @@ const mockAvailableWallets = [
 
 describe("Navbar", () => {
   function renderNavbar(ui: ReactElement) {
-    return render(<ThemeProvider>{ui}</ThemeProvider>);
+    const storage = {
+      getItem: jest.fn(() => null),
+      setItem: jest.fn(),
+      removeItem: jest.fn(),
+    };
+    const store = new WorkspaceStore(storage);
+
+    return render(
+      <WorkspaceProvider store={store}>
+        <ThemeProvider>{ui}</ThemeProvider>
+      </WorkspaceProvider>
+    );
   }
 
   test("shows connect button when disconnected", async () => {

--- a/tests/contexts/ThemeContext.test.tsx
+++ b/tests/contexts/ThemeContext.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, act } from '@testing-library/react';
 import { ThemeProvider, useTheme } from '@/contexts/ThemeContext';
-import userEvent from '@testing-library/user-event';
+import { WorkspaceProvider, WORKSPACE_STORAGE_KEY, WorkspaceStore } from '@/workspaces';
 
 interface MockMediaQueryList extends MediaQueryList {
   triggerChange: (newMatches: boolean) => void;
@@ -63,6 +63,23 @@ const TestComponent = () => {
   );
 };
 
+function createMemoryStorage(initial: Record<string, string> = {}) {
+  const data = new Map(Object.entries(initial));
+  return {
+    getItem: jest.fn((key: string) => data.get(key) ?? null),
+    setItem: jest.fn((key: string, value: string) => {
+      data.set(key, value);
+    }),
+    removeItem: jest.fn((key: string) => {
+      data.delete(key);
+    }),
+    clear: jest.fn(() => {
+      data.clear();
+    }),
+    read: (key: string) => data.get(key) ?? null,
+  };
+}
+
 describe('ThemeContext', () => {
   let matchMediaMock: any;
 
@@ -116,7 +133,6 @@ describe('ThemeContext', () => {
   });
 
   it('updates theme and localStorage when setTheme is called', async () => {
-    const user = userEvent.setup({ delay: null });
     render(
       <ThemeProvider>
         <TestComponent />
@@ -130,6 +146,31 @@ describe('ThemeContext', () => {
     expect(screen.getByTestId('theme').textContent).toBe('dark');
     expect(screen.getByTestId('resolved').textContent).toBe('dark');
     expect(localStorage.getItem('theme-preference')).toBe('dark');
+  });
+
+  it('migrates legacy theme preference into the active workspace', async () => {
+    const storage = createMemoryStorage({ 'theme-preference': 'dark' });
+    Object.defineProperty(window, 'localStorage', {
+      value: storage,
+      configurable: true,
+    });
+    const store = new WorkspaceStore(storage);
+
+    render(
+      <WorkspaceProvider store={store}>
+        <ThemeProvider>
+          <TestComponent />
+        </ThemeProvider>
+      </WorkspaceProvider>
+    );
+
+    await screen.findByTestId('theme');
+    expect(screen.getByTestId('theme').textContent).toBe('dark');
+    expect(store.getActiveWorkspace().preferences.theme).toBe('dark');
+    expect(storage.removeItem).toHaveBeenCalledWith('theme-preference');
+
+    const persistedState = JSON.parse(storage.read(WORKSPACE_STORAGE_KEY) ?? '{}');
+    expect(persistedState.workspaces[0].preferences.theme).toBe('dark');
   });
 
   it('updates resolved theme when system preference changes', async () => {

--- a/tests/workspaces/workspaceStore.test.ts
+++ b/tests/workspaces/workspaceStore.test.ts
@@ -1,0 +1,117 @@
+import {
+  createDefaultWorkspace,
+  normalizeWorkspaceState,
+  WORKSPACE_STORAGE_KEY,
+  WorkspaceStore,
+} from "@/workspaces";
+
+function createMemoryStorage(initial?: string) {
+  const data = new Map<string, string>();
+  if (initial) data.set(WORKSPACE_STORAGE_KEY, initial);
+  return {
+    getItem: jest.fn((key: string) => data.get(key) ?? null),
+    setItem: jest.fn((key: string, value: string) => {
+      data.set(key, value);
+    }),
+    removeItem: jest.fn((key: string) => {
+      data.delete(key);
+    }),
+  };
+}
+
+describe("WorkspaceStore", () => {
+  test("creates a default workspace when storage is empty", () => {
+    const storage = createMemoryStorage();
+    const store = new WorkspaceStore(storage);
+
+    expect(store.getSnapshot().workspaces).toHaveLength(1);
+    expect(store.getActiveWorkspace().name).toBe("Default workspace");
+    expect(storage.getItem).toHaveBeenCalledWith(WORKSPACE_STORAGE_KEY);
+  });
+
+  test("creates and switches workspaces while persisting state", () => {
+    const storage = createMemoryStorage();
+    const store = new WorkspaceStore(storage);
+
+    const workspace = store.createWorkspace("Trading desk", {
+      preferences: { network: "mainnet" },
+      layout: { sidebarOpen: false },
+    });
+
+    expect(store.getSnapshot().workspaces).toHaveLength(2);
+    expect(store.getActiveWorkspace().id).toBe(workspace.id);
+    expect(store.getActiveWorkspace().preferences.network).toBe("mainnet");
+    expect(storage.setItem).toHaveBeenCalledWith(
+      WORKSPACE_STORAGE_KEY,
+      expect.stringContaining("Trading desk"),
+    );
+
+    store.switchWorkspace("default");
+    expect(store.getActiveWorkspace().id).toBe("default");
+  });
+
+  test("keeps layout and preferences isolated per workspace", () => {
+    const store = new WorkspaceStore(createMemoryStorage());
+    const research = store.createWorkspace("Research");
+    store.updateWorkspace(research.id, {
+      layout: { sidebarOpen: false, defaultView: "analytics" },
+      preferences: { theme: "dark", pinnedWallets: ["GABC"] },
+    });
+
+    store.switchWorkspace("default");
+    expect(store.getActiveWorkspace().layout.sidebarOpen).toBe(true);
+    expect(store.getActiveWorkspace().preferences.theme).toBe("system");
+
+    store.switchWorkspace(research.id);
+    expect(store.getActiveWorkspace().layout.sidebarOpen).toBe(false);
+    expect(store.getActiveWorkspace().layout.defaultView).toBe("analytics");
+    expect(store.getActiveWorkspace().preferences.pinnedWallets).toEqual(["GABC"]);
+  });
+
+  test("normalizes invalid persisted state", () => {
+    const state = normalizeWorkspaceState({
+      version: 1,
+      activeWorkspaceId: "missing",
+      workspaces: [
+        {
+          ...createDefaultWorkspace("2026-01-01T00:00:00.000Z"),
+          id: "",
+          name: "",
+          layout: { visibleViews: [] },
+          preferences: { pinnedWallets: "invalid" },
+        },
+      ],
+    });
+
+    expect(state.activeWorkspaceId).toBe("default");
+    expect(state.workspaces[0].name).toBe("Default workspace");
+    expect(state.workspaces[0].layout.visibleViews).toContain("vault");
+    expect(state.workspaces[0].preferences.pinnedWallets).toEqual([]);
+  });
+
+  test("falls back when storage contains invalid JSON", () => {
+    const storage = createMemoryStorage("{bad json");
+    const store = new WorkspaceStore(storage);
+
+    const snapshot = store.getSnapshot();
+    expect(snapshot).toMatchObject({
+      version: 1,
+      activeWorkspaceId: "default",
+    });
+    expect(snapshot.workspaces).toHaveLength(1);
+    expect(snapshot.workspaces[0]).toMatchObject({
+      id: "default",
+      name: "Default workspace",
+      layout: {
+        sidebarOpen: true,
+        defaultView: "vault",
+      },
+      preferences: {
+        theme: "system",
+        network: "testnet",
+        pinnedWallets: [],
+      },
+    });
+    expect(storage.removeItem).toHaveBeenCalledWith(WORKSPACE_STORAGE_KEY);
+  });
+});


### PR DESCRIPTION
## Summary
- add a local workspace architecture for creating, switching, updating, and deleting isolated dashboard workspaces
- persist workspace layout and preference state under a versioned localStorage model, including sidebar and theme migration from legacy keys
- wire workspace switching into the app shell/navbar and workspace-aware theme/bootstrap handling
- document the workspace API, persistence strategy, migration behavior, and local-only scope
- add focused tests for workspace management, layout/preference isolation, sidebar migration, theme migration, navbar integration, and theme bootstrap behavior
- fix existing TypeScript blockers so the branch passes repository typecheck

Closes #256

## Verification
- npm run typecheck
- npm test -- --runTestsByPath tests/workspaces/workspaceStore.test.ts src/hooks/useSidebar.test.ts tests/components/Navbar.test.tsx tests/contexts/ThemeContext.test.tsx src/utils/__tests__/themeBootstrap.test.ts
- git diff --check