### PR TITLE
feat: add notification center (#268)

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useSidebar } from "@/hooks/useSidebar";
 import { shortenAddress } from "@/utils/contractHelpers";
 import ThemeToggle from "./ThemeToggle";
+import { NotificationCenter } from "@/components/notifications";
 import { WalletId, WalletMeta } from "@/types/wallet";
 
 type NavbarProps = {
@@ -179,6 +180,7 @@ export default function Navbar({
         </div>
 
         <div className="flex items-center gap-4">
+          <NotificationCenter />
           <ThemeToggle />
 
           {/* ── Connected state ─────────────────────────────────────────── */}

--- a/src/components/notifications/NotificationCenter.tsx
+++ b/src/components/notifications/NotificationCenter.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useRef, useState } from 'react';
+import { Bell } from 'lucide-react';
+
+import { IconButton } from '@/design-system';
+import { NOTIFICATION_ACTION_CLASS } from '@/notifications/constants';
+import { useNotifications } from '@/hooks/useNotifications';
+import { cn } from '@/lib/utils';
+import NotificationFilters from './NotificationFilters';
+import NotificationItem from './NotificationItem';
+
+/**
+ * Navbar notification center panel (#268). Displays priority-sorted alerts
+ * with category/read filters, dismissal, and persistent read state.
+ */
+export default function NotificationCenter() {
+  const [isOpen, setIsOpen] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const {
+    notifications,
+    unreadCount,
+    filter,
+    markAsRead,
+    markAllAsRead,
+    dismiss,
+    dismissAllVisible,
+    setFilter,
+  } = useNotifications();
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    function handleClickOutside(e: MouseEvent) {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        setIsOpen(false);
+        document.getElementById('notification-center-button')?.focus();
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen]);
+
+  const unreadLabel =
+    unreadCount === 0
+      ? 'Notifications'
+      : `Notifications, ${unreadCount} unread`;
+
+  return (
+    <div className="relative" ref={panelRef}>
+      <IconButton
+        id="notification-center-button"
+        label={unreadLabel}
+        variant="default"
+        aria-haspopup="true"
+        aria-expanded={isOpen}
+        aria-controls="notification-center-panel"
+        onClick={() => setIsOpen((v) => !v)}
+        className="relative"
+      >
+        <Bell className="h-4 w-4" strokeWidth={2} />
+      </IconButton>
+
+      {unreadCount > 0 ? (
+        <span
+          className="pointer-events-none absolute -right-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-axion-500 px-1 text-[10px] font-semibold text-white"
+          aria-hidden="true"
+        >
+          {unreadCount > 99 ? '99+' : unreadCount}
+        </span>
+      ) : null}
+
+      {isOpen ? (
+        <div
+          id="notification-center-panel"
+          role="region"
+          aria-label="Notification center"
+          className="absolute right-0 z-50 mt-2 w-80 origin-top-right overflow-hidden rounded-2xl border border-border-primary bg-background-primary shadow-xl ring-1 ring-black/5 dark:ring-white/5 sm:w-96"
+        >
+          <header className="flex items-center justify-between gap-2 px-4 py-3">
+            <h2 className="text-sm font-semibold text-text-primary">Notifications</h2>
+            <div className="flex gap-1">
+              {unreadCount > 0 ? (
+                <button
+                  type="button"
+                  onClick={markAllAsRead}
+                  className={cn(NOTIFICATION_ACTION_CLASS, 'text-axion-500 hover:bg-background-secondary/60')}
+                >
+                  Mark all read
+                </button>
+              ) : null}
+              {notifications.length > 0 ? (
+                <button
+                  type="button"
+                  onClick={dismissAllVisible}
+                  className={cn(NOTIFICATION_ACTION_CLASS, 'text-text-secondary hover:bg-background-secondary/60')}
+                >
+                  Dismiss all
+                </button>
+              ) : null}
+            </div>
+          </header>
+
+          <NotificationFilters filter={filter} onFilterChange={setFilter} />
+
+          <div
+            className="max-h-96 overflow-y-auto px-3 py-2"
+            aria-live="polite"
+            aria-relevant="additions text"
+          >
+            {notifications.length === 0 ? (
+              <p className="py-10 text-center text-sm text-text-secondary">
+                No notifications match the current filters.
+              </p>
+            ) : (
+              <ul className="flex flex-col gap-2 py-2">
+                {notifications.map((notification) => (
+                  <NotificationItem
+                    key={notification.id}
+                    notification={notification}
+                    onMarkRead={markAsRead}
+                    onDismiss={dismiss}
+                  />
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/notifications/NotificationFilters.tsx
+++ b/src/components/notifications/NotificationFilters.tsx
@@ -1,0 +1,59 @@
+import {
+  NOTIFICATION_FILTER_CATEGORIES,
+  NOTIFICATION_READ_FILTERS,
+} from '@/notifications/constants';
+import type {
+  NotificationFilter,
+  NotificationFilterCategory,
+  NotificationFilterRead,
+} from '@/notifications/types';
+
+export interface NotificationFiltersProps {
+  filter: NotificationFilter;
+  onFilterChange: (filter: Partial<NotificationFilter>) => void;
+}
+
+export default function NotificationFilters({
+  filter,
+  onFilterChange,
+}: NotificationFiltersProps) {
+  return (
+    <div className="flex flex-wrap gap-2 border-b border-border-primary px-3 py-2">
+      <label className="sr-only" htmlFor="notification-category-filter">
+        Filter by category
+      </label>
+      <select
+        id="notification-category-filter"
+        value={filter.category}
+        onChange={(e) =>
+          onFilterChange({ category: e.target.value as NotificationFilterCategory })
+        }
+        className="rounded-lg border border-border-primary bg-background-secondary/30 px-2 py-1 text-xs text-text-primary focus:border-axion-500 focus:outline-none"
+      >
+        {NOTIFICATION_FILTER_CATEGORIES.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+
+      <label className="sr-only" htmlFor="notification-read-filter">
+        Filter by read status
+      </label>
+      <select
+        id="notification-read-filter"
+        value={filter.read}
+        onChange={(e) =>
+          onFilterChange({ read: e.target.value as NotificationFilterRead })
+        }
+        className="rounded-lg border border-border-primary bg-background-secondary/30 px-2 py-1 text-xs text-text-primary focus:border-axion-500 focus:outline-none"
+      >
+        {NOTIFICATION_READ_FILTERS.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/components/notifications/NotificationItem.tsx
+++ b/src/components/notifications/NotificationItem.tsx
@@ -1,0 +1,100 @@
+import { cn } from '@/lib/utils';
+import { Badge } from '@/design-system';
+import {
+  NOTIFICATION_ACTION_CLASS,
+  NOTIFICATION_CATEGORY_LABELS,
+} from '@/notifications/constants';
+import type { AppNotification, NotificationCategory, NotificationPriority } from '@/notifications/types';
+
+const CATEGORY_BADGE: Record<NotificationCategory, 'info' | 'success' | 'warning' | 'default'> = {
+  protocol: 'info',
+  transaction: 'default',
+  governance: 'warning',
+  reward: 'success',
+};
+
+const PRIORITY_DOT: Record<NotificationPriority, string> = {
+  critical: 'bg-rose-500',
+  high: 'bg-amber-500',
+  normal: 'bg-axion-500',
+  low: 'bg-slate-400',
+};
+
+function formatTimestamp(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return timestamp;
+  return date.toLocaleString();
+}
+
+export interface NotificationItemProps {
+  notification: AppNotification;
+  onMarkRead: (id: string) => void;
+  onDismiss: (id: string) => void;
+}
+
+export default function NotificationItem({
+  notification,
+  onMarkRead,
+  onDismiss,
+}: NotificationItemProps) {
+  const category = notification.category;
+
+  return (
+    <li
+      className={cn(
+        'rounded-xl border border-border-primary p-3 transition',
+        notification.read
+          ? 'bg-background-secondary/10 opacity-80'
+          : 'bg-background-secondary/30',
+      )}
+    >
+      <div className="flex items-start gap-2">
+        <span
+          className={cn(
+            'mt-1.5 h-2 w-2 shrink-0 rounded-full',
+            PRIORITY_DOT[notification.priority],
+          )}
+          aria-hidden="true"
+          title={`${notification.priority} priority`}
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="text-sm font-medium text-text-primary">{notification.title}</p>
+            <Badge variant={CATEGORY_BADGE[category]}>
+              {NOTIFICATION_CATEGORY_LABELS[category]}
+            </Badge>
+            {!notification.read ? (
+              <span className="sr-only">Unread</span>
+            ) : null}
+          </div>
+          <p className="mt-1 text-xs text-text-secondary">{notification.message}</p>
+          <time
+            className="mt-1 block text-[10px] text-text-muted"
+            dateTime={notification.timestamp}
+          >
+            {formatTimestamp(notification.timestamp)}
+          </time>
+        </div>
+      </div>
+
+      <div className="mt-2 flex justify-end gap-2">
+        {!notification.read ? (
+          <button
+            type="button"
+            onClick={() => onMarkRead(notification.id)}
+            className={cn(NOTIFICATION_ACTION_CLASS, 'text-axion-500 hover:bg-background-secondary/60')}
+          >
+            Mark read
+          </button>
+        ) : null}
+        <button
+          type="button"
+          onClick={() => onDismiss(notification.id)}
+          className={cn(NOTIFICATION_ACTION_CLASS, 'text-text-secondary hover:bg-background-secondary/60')}
+        >
+          Dismiss
+        </button>
+      </div>
+    </li>
+  );
+}

--- a/src/components/notifications/index.ts
+++ b/src/components/notifications/index.ts
@@ -1,0 +1,3 @@
+export { default as NotificationCenter } from './NotificationCenter';
+export { default as NotificationItem } from './NotificationItem';
+export { default as NotificationFilters } from './NotificationFilters';

--- a/src/hooks/useActivityFeed.ts
+++ b/src/hooks/useActivityFeed.ts
@@ -4,35 +4,13 @@ import {
   getEventSubscriptionService,
   type EventSubscriptionService,
 } from '@/services/events';
+import { subscribeSharedEventStream } from '@/services/events/sharedStreamLifecycle';
 
 export interface UseActivityFeedOptions {
   /** Start streaming on mount (default true). */
   enabled?: boolean;
   /** Inject a service instance (tests / storybook). Defaults to the singleton. */
   service?: EventSubscriptionService;
-}
-
-// Module-level bridge + refcount so the shared service is connected to the
-// shared store exactly once, regardless of how many components use the hook,
-// and is stopped only when the last consumer unmounts.
-let consumers = 0;
-let unbind: (() => void) | null = null;
-
-function startBridge(service: EventSubscriptionService): void {
-  if (unbind) return;
-  const offEvent = service.onEvent((event) => activityStore.addEvent(event));
-  const offStatus = service.onStatusChange((status) => activityStore.setStatus(status));
-  service.start();
-  unbind = () => {
-    offEvent();
-    offStatus();
-    service.stop();
-  };
-}
-
-function stopBridge(): void {
-  unbind?.();
-  unbind = null;
 }
 
 /**
@@ -52,16 +30,10 @@ export function useActivityFeed(options: UseActivityFeedOptions = {}) {
   useEffect(() => {
     if (!enabled) return;
     const svc = service ?? getEventSubscriptionService();
-    consumers += 1;
-    startBridge(svc);
-
-    return () => {
-      consumers -= 1;
-      if (consumers <= 0) {
-        consumers = 0;
-        stopBridge();
-      }
-    };
+    return subscribeSharedEventStream(svc, {
+      onEvent: (event) => activityStore.addEvent(event),
+      onStatusChange: (status) => activityStore.setStatus(status),
+    });
   }, [enabled, service]);
 
   const clear = useCallback(() => activityStore.clear(), []);

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,0 +1,84 @@
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from 'react';
+import { subscribeNotificationActivityBridge } from '@/notifications/activityBridge';
+import {
+  selectUnreadCount,
+  selectVisibleNotifications,
+} from '@/notifications/selectors';
+import type { NotificationFilter } from '@/notifications/types';
+import {
+  getEventSubscriptionService,
+  type EventSubscriptionService,
+} from '@/services/events';
+import { notificationStore } from '@/store/notificationStore';
+
+export interface UseNotificationsOptions {
+  /** Bridge live protocol events into the notification center (default true). */
+  subscribeToActivity?: boolean;
+  /** Inject a service instance (tests). Defaults to the singleton. */
+  service?: EventSubscriptionService;
+}
+
+/**
+ * Subscribes to the notification center store and exposes filtered,
+ * priority-sorted notifications plus lifecycle actions (#268).
+ */
+export function useNotifications(options: UseNotificationsOptions = {}) {
+  const { subscribeToActivity = true, service } = options;
+
+  useEffect(() => {
+    notificationStore.hydrate();
+  }, []);
+
+  const snapshot = useSyncExternalStore(
+    notificationStore.subscribe,
+    notificationStore.getSnapshot,
+    notificationStore.getSnapshot,
+  );
+
+  useEffect(() => {
+    if (!subscribeToActivity) return;
+    const svc = service ?? getEventSubscriptionService();
+    return subscribeNotificationActivityBridge(svc);
+  }, [subscribeToActivity, service]);
+
+  const notifications = useMemo(
+    () => selectVisibleNotifications(snapshot.items, snapshot.filter),
+    [snapshot.items, snapshot.filter],
+  );
+
+  const unreadCount = useMemo(
+    () => selectUnreadCount(snapshot.items),
+    [snapshot.items],
+  );
+
+  const markAsRead = useCallback((id: string) => {
+    notificationStore.markAsRead(id);
+  }, []);
+
+  const markAllAsRead = useCallback(() => {
+    notificationStore.markAllAsRead();
+  }, []);
+
+  const dismiss = useCallback((id: string) => {
+    notificationStore.dismiss(id);
+  }, []);
+
+  const dismissAllVisible = useCallback(() => {
+    notificationStore.dismissAllVisible();
+  }, []);
+
+  const setFilter = useCallback((filter: Partial<NotificationFilter>) => {
+    notificationStore.setFilter(filter);
+  }, []);
+
+  return {
+    notifications,
+    unreadCount,
+    filter: snapshot.filter,
+    markAsRead,
+    markAllAsRead,
+    dismiss,
+    dismissAllVisible,
+    setFilter,
+  };
+}

--- a/src/notifications/activityBridge.ts
+++ b/src/notifications/activityBridge.ts
@@ -1,0 +1,37 @@
+import { notificationFromActivityEvent } from '@/notifications/adapters/fromActivityEvent';
+import type { NotificationInput } from '@/notifications/types';
+import type { EventSubscriptionService } from '@/services/events';
+import { subscribeSharedEventStream } from '@/services/events/sharedStreamLifecycle';
+import { notificationStore } from '@/store/notificationStore';
+
+const PROTOCOL_STREAM_ERROR: NotificationInput = {
+  id: 'protocol:stream-error',
+  category: 'protocol',
+  priority: 'high',
+  title: 'Event stream interrupted',
+  message: 'Could not connect to the protocol event stream. Retrying…',
+  timestamp: new Date().toISOString(),
+};
+
+/**
+ * Subscribes the notification store to live protocol events (#215 → #268).
+ * Uses the shared event-stream lifecycle so unmounting the notification
+ * panel does not stop the stream for other consumers.
+ */
+export function subscribeNotificationActivityBridge(
+  service: EventSubscriptionService,
+): () => void {
+  return subscribeSharedEventStream(service, {
+    onEvent: (event) => {
+      notificationStore.addNotification(notificationFromActivityEvent(event));
+    },
+    onStatusChange: (status) => {
+      if (status === 'error') {
+        notificationStore.addNotification({
+          ...PROTOCOL_STREAM_ERROR,
+          timestamp: new Date().toISOString(),
+        });
+      }
+    },
+  });
+}

--- a/src/notifications/adapters/fromActivityEvent.ts
+++ b/src/notifications/adapters/fromActivityEvent.ts
@@ -1,0 +1,55 @@
+import type { ActivityEvent, ActivityType } from '@/services/events/types';
+import type { NotificationCategory, NotificationInput, NotificationPriority } from '../types';
+
+const ACTIVITY_CATEGORY: Record<ActivityType, NotificationCategory> = {
+  deposit: 'transaction',
+  withdrawal: 'transaction',
+  reward: 'reward',
+  governance: 'governance',
+  unknown: 'protocol',
+};
+
+const ACTIVITY_PRIORITY: Record<ActivityType, NotificationPriority> = {
+  deposit: 'normal',
+  withdrawal: 'normal',
+  reward: 'high',
+  governance: 'high',
+  unknown: 'low',
+};
+
+const ACTIVITY_TITLE: Record<ActivityType, string> = {
+  deposit: 'Deposit detected',
+  withdrawal: 'Withdrawal detected',
+  reward: 'Reward event',
+  governance: 'Governance activity',
+  unknown: 'Protocol event',
+};
+
+function buildMessage(event: ActivityEvent): string {
+  const label = event.name && event.name !== 'unknown' ? event.name : event.type;
+  return `${label} on ledger #${event.ledger}`;
+}
+
+/**
+ * Maps a normalized {@link ActivityEvent} (issue #215) into a notification input.
+ */
+export function notificationFromActivityEvent(event: ActivityEvent): NotificationInput {
+  const category = ACTIVITY_CATEGORY[event.type] ?? 'protocol';
+  const priority = ACTIVITY_PRIORITY[event.type] ?? 'normal';
+  const title = ACTIVITY_TITLE[event.type] ?? 'Protocol event';
+
+  return {
+    id: `activity:${event.id}`,
+    sourceId: event.id,
+    category,
+    priority,
+    title,
+    message: buildMessage(event),
+    timestamp: event.timestamp,
+    metadata: {
+      contractId: event.contractId,
+      ledger: event.ledger,
+      activityType: event.type,
+    },
+  };
+}

--- a/src/notifications/constants.ts
+++ b/src/notifications/constants.ts
@@ -1,0 +1,28 @@
+import type { NotificationCategory, NotificationFilterCategory } from './types';
+
+export const NOTIFICATION_CATEGORY_LABELS: Record<NotificationCategory, string> = {
+  protocol: 'Protocol',
+  transaction: 'Transaction',
+  governance: 'Governance',
+  reward: 'Reward',
+};
+
+export const NOTIFICATION_FILTER_CATEGORIES: {
+  value: NotificationFilterCategory;
+  label: string;
+}[] = [
+  { value: 'all', label: 'All categories' },
+  { value: 'protocol', label: 'Protocol' },
+  { value: 'transaction', label: 'Transactions' },
+  { value: 'governance', label: 'Governance' },
+  { value: 'reward', label: 'Rewards' },
+];
+
+export const NOTIFICATION_READ_FILTERS = [
+  { value: 'all' as const, label: 'All' },
+  { value: 'unread' as const, label: 'Unread' },
+  { value: 'read' as const, label: 'Read' },
+];
+
+export const NOTIFICATION_ACTION_CLASS =
+  'rounded-lg px-2 py-1 text-xs focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500';

--- a/src/notifications/filtering.ts
+++ b/src/notifications/filtering.ts
@@ -1,0 +1,18 @@
+import type { AppNotification, NotificationFilter } from './types';
+
+/**
+ * Returns visible notifications after applying active filters.
+ * Dismissed items are always excluded from the center panel.
+ */
+export function applyNotificationFilter(
+  items: AppNotification[],
+  filter: NotificationFilter,
+): AppNotification[] {
+  return items.filter((item) => {
+    if (item.dismissed) return false;
+    if (filter.category !== 'all' && item.category !== filter.category) return false;
+    if (filter.read === 'unread' && item.read) return false;
+    if (filter.read === 'read' && !item.read) return false;
+    return true;
+  });
+}

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -1,0 +1,40 @@
+export type {
+  AppNotification,
+  NotificationCategory,
+  NotificationFilter,
+  NotificationFilterCategory,
+  NotificationFilterRead,
+  NotificationInput,
+  NotificationPriority,
+  NotificationState,
+} from './types';
+
+export {
+  DEFAULT_NOTIFICATION_FILTER,
+  NOTIFICATION_STORAGE_VERSION,
+} from './types';
+
+export { compareByPriority, sortByPriority } from './prioritization';
+export { applyNotificationFilter } from './filtering';
+export { selectUnreadCount, selectVisibleNotifications } from './selectors';
+export {
+  NOTIFICATION_ACTION_CLASS,
+  NOTIFICATION_CATEGORY_LABELS,
+  NOTIFICATION_FILTER_CATEGORIES,
+  NOTIFICATION_READ_FILTERS,
+} from './constants';
+export { subscribeNotificationActivityBridge } from './activityBridge';
+export {
+  loadNotificationState,
+  saveNotificationState,
+  clearNotificationStorage,
+} from './persistence';
+export type { PersistedNotificationState } from './persistence';
+export { notificationFromActivityEvent } from './adapters/fromActivityEvent';
+
+export {
+  notificationStore,
+  pushNotification,
+  pushNotifications,
+  NotificationStore,
+} from '@/store/notificationStore';

--- a/src/notifications/normalize.ts
+++ b/src/notifications/normalize.ts
@@ -1,0 +1,54 @@
+import type { AppNotification, NotificationInput } from './types';
+
+/** Applies defaults for optional ingest fields. */
+export function normalizeNotificationInput(input: NotificationInput): AppNotification {
+  return {
+    ...input,
+    read: input.read ?? false,
+    dismissed: input.dismissed ?? false,
+  };
+}
+
+/** Returns inputs that are not already tracked by id or sourceId. */
+export function filterFreshNotifications(
+  incoming: NotificationInput[],
+  seenIds: ReadonlySet<string>,
+  seenSourceIds: ReadonlySet<string>,
+): NotificationInput[] {
+  return incoming.filter((n) => {
+    if (seenIds.has(n.id)) return false;
+    if (n.sourceId && seenSourceIds.has(n.sourceId)) return false;
+    return true;
+  });
+}
+
+/** Registers ids from notifications into dedupe sets. */
+export function trackNotificationIds(
+  items: AppNotification[],
+  seenIds: Set<string>,
+  seenSourceIds: Set<string>,
+): void {
+  items.forEach((n) => {
+    seenIds.add(n.id);
+    if (n.sourceId) seenSourceIds.add(n.sourceId);
+  });
+}
+
+/** Prunes dedupe sets to match retained notifications after capping. */
+export function syncDedupeSets(
+  items: AppNotification[],
+  seenIds: Set<string>,
+  seenSourceIds: Set<string>,
+): void {
+  const retainedIds = new Set(items.map((n) => n.id));
+  const retainedSources = new Set(
+    items.flatMap((n) => (n.sourceId ? [n.sourceId] : [])),
+  );
+
+  for (const id of seenIds) {
+    if (!retainedIds.has(id)) seenIds.delete(id);
+  }
+  for (const sourceId of seenSourceIds) {
+    if (!retainedSources.has(sourceId)) seenSourceIds.delete(sourceId);
+  }
+}

--- a/src/notifications/persistence.ts
+++ b/src/notifications/persistence.ts
@@ -1,0 +1,46 @@
+import type { AppNotification, NotificationFilter } from './types';
+import { DEFAULT_NOTIFICATION_FILTER, NOTIFICATION_STORAGE_VERSION } from './types';
+
+const STORAGE_KEY = `axionvera:notifications:v${NOTIFICATION_STORAGE_VERSION}`;
+
+export interface PersistedNotificationState {
+  version: number;
+  items: AppNotification[];
+  filter: NotificationFilter;
+}
+
+export function loadNotificationState(): PersistedNotificationState | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as PersistedNotificationState;
+    if (parsed.version !== NOTIFICATION_STORAGE_VERSION) return null;
+    if (!Array.isArray(parsed.items)) return null;
+    return {
+      version: NOTIFICATION_STORAGE_VERSION,
+      items: parsed.items,
+      filter: parsed.filter ?? DEFAULT_NOTIFICATION_FILTER,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function saveNotificationState(state: PersistedNotificationState): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (error) {
+    console.warn('[NotificationPersistence] Failed to save state:', error);
+  }
+}
+
+export function clearNotificationStorage(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+}

--- a/src/notifications/prioritization.ts
+++ b/src/notifications/prioritization.ts
@@ -1,0 +1,21 @@
+import type { AppNotification, NotificationPriority } from './types';
+
+const PRIORITY_RANK: Record<NotificationPriority, number> = {
+  critical: 0,
+  high: 1,
+  normal: 2,
+  low: 3,
+};
+
+/**
+ * Sort notifications by priority (critical first), then newest timestamp.
+ */
+export function compareByPriority(a: AppNotification, b: AppNotification): number {
+  const rankDiff = PRIORITY_RANK[a.priority] - PRIORITY_RANK[b.priority];
+  if (rankDiff !== 0) return rankDiff;
+  return new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
+}
+
+export function sortByPriority(items: AppNotification[]): AppNotification[] {
+  return [...items].sort(compareByPriority);
+}

--- a/src/notifications/selectors.ts
+++ b/src/notifications/selectors.ts
@@ -1,0 +1,16 @@
+import type { AppNotification, NotificationFilter } from './types';
+import { applyNotificationFilter } from './filtering';
+import { sortByPriority } from './prioritization';
+
+/** Unread, non-dismissed count derived from raw store items. */
+export function selectUnreadCount(items: AppNotification[]): number {
+  return items.filter((n) => !n.read && !n.dismissed).length;
+}
+
+/** Filtered + priority-sorted list for the notification panel. */
+export function selectVisibleNotifications(
+  items: AppNotification[],
+  filter: NotificationFilter,
+): AppNotification[] {
+  return sortByPriority(applyNotificationFilter(items, filter));
+}

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -1,0 +1,58 @@
+/**
+ * Notification categories surfaced in the notification center (#268).
+ */
+export type NotificationCategory =
+  | 'protocol'
+  | 'transaction'
+  | 'governance'
+  | 'reward';
+
+/** Higher values sort first when timestamps are equal. */
+export type NotificationPriority = 'low' | 'normal' | 'high' | 'critical';
+
+/**
+ * UI-ready notification record persisted in the dashboard store.
+ */
+export interface AppNotification {
+  /** Stable unique id (deduplication + React keys). */
+  id: string;
+  category: NotificationCategory;
+  priority: NotificationPriority;
+  title: string;
+  message: string;
+  /** ISO-8601 timestamp. */
+  timestamp: string;
+  read: boolean;
+  dismissed: boolean;
+  /** Optional upstream id (e.g. activity event id) for idempotent ingestion. */
+  sourceId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export type NotificationFilterCategory = 'all' | NotificationCategory;
+
+export type NotificationFilterRead = 'all' | 'unread' | 'read';
+
+export interface NotificationFilter {
+  category: NotificationFilterCategory;
+  read: NotificationFilterRead;
+}
+
+export interface NotificationState {
+  items: AppNotification[];
+  filter: NotificationFilter;
+  lastUpdated: number | null;
+}
+
+/** Payload accepted by {@link pushNotification} — read/dismissed default at ingest. */
+export type NotificationInput = Omit<AppNotification, 'read' | 'dismissed'> & {
+  read?: boolean;
+  dismissed?: boolean;
+};
+
+export const DEFAULT_NOTIFICATION_FILTER: NotificationFilter = {
+  category: 'all',
+  read: 'all',
+};
+
+export const NOTIFICATION_STORAGE_VERSION = 1;

--- a/src/services/events/sharedStreamLifecycle.ts
+++ b/src/services/events/sharedStreamLifecycle.ts
@@ -1,0 +1,61 @@
+import type {
+  EventListener,
+  EventSubscriptionService,
+  StatusListener,
+} from './types';
+
+export interface EventStreamHandlers {
+  onEvent: EventListener;
+  onStatusChange?: StatusListener;
+}
+
+/**
+ * Reference-counted lifecycle for the shared {@link EventSubscriptionService}.
+ * Multiple hooks (activity feed, notification bridge) can subscribe without
+ * one unmount stopping the stream for everyone else.
+ */
+export function subscribeSharedEventStream(
+  service: EventSubscriptionService,
+  handlers: EventStreamHandlers,
+): () => void {
+  const release = acquireSharedStream(service);
+  const offEvent = service.onEvent(handlers.onEvent);
+  const offStatus = handlers.onStatusChange
+    ? service.onStatusChange(handlers.onStatusChange)
+    : null;
+
+  return () => {
+    offEvent();
+    offStatus?.();
+    release();
+  };
+}
+
+let streamConsumers = 0;
+let activeService: EventSubscriptionService | null = null;
+
+function acquireSharedStream(service: EventSubscriptionService): () => void {
+  streamConsumers += 1;
+  if (streamConsumers === 1) {
+    activeService = service;
+    service.start();
+  }
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    streamConsumers -= 1;
+    if (streamConsumers <= 0) {
+      streamConsumers = 0;
+      activeService?.stop();
+      activeService = null;
+    }
+  };
+}
+
+/** Test helper — reset module-level refcount state. */
+export function resetSharedEventStreamForTests(): void {
+  streamConsumers = 0;
+  activeService = null;
+}

--- a/src/store/notificationStore.ts
+++ b/src/store/notificationStore.ts
@@ -1,0 +1,220 @@
+import { applyNotificationFilter } from '@/notifications/filtering';
+import {
+  filterFreshNotifications,
+  normalizeNotificationInput,
+  syncDedupeSets,
+  trackNotificationIds,
+} from '@/notifications/normalize';
+import {
+  loadNotificationState,
+  saveNotificationState,
+} from '@/notifications/persistence';
+import { sortByPriority } from '@/notifications/prioritization';
+import {
+  selectUnreadCount,
+  selectVisibleNotifications,
+} from '@/notifications/selectors';
+import type {
+  AppNotification,
+  NotificationFilter,
+  NotificationInput,
+  NotificationState,
+} from '@/notifications/types';
+import {
+  DEFAULT_NOTIFICATION_FILTER,
+  NOTIFICATION_STORAGE_VERSION,
+} from '@/notifications/types';
+
+const DEFAULT_MAX_ITEMS = 100;
+
+/**
+ * Framework-agnostic observable store for the notification center (#268).
+ *
+ * Consumed via `useSyncExternalStore` in {@link useNotifications}. Persists
+ * read/unread and dismissal state to localStorage. Ingestion is idempotent:
+ * duplicates (by id or sourceId) are ignored.
+ */
+export class NotificationStore {
+  private state: NotificationState = {
+    items: [],
+    filter: DEFAULT_NOTIFICATION_FILTER,
+    lastUpdated: null,
+  };
+
+  private readonly listeners = new Set<() => void>();
+  private readonly seenIds = new Set<string>();
+  private readonly seenSourceIds = new Set<string>();
+  private readonly maxItems: number;
+  private hydrated = false;
+
+  constructor(maxItems: number = DEFAULT_MAX_ITEMS) {
+    this.maxItems = maxItems;
+    this.subscribe = this.subscribe.bind(this);
+    this.getSnapshot = this.getSnapshot.bind(this);
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  getSnapshot(): NotificationState {
+    return this.state;
+  }
+
+  /** Load persisted state from localStorage (browser only, once). */
+  hydrate(): void {
+    if (this.hydrated || typeof window === 'undefined') return;
+    this.hydrated = true;
+
+    const persisted = loadNotificationState();
+    if (!persisted) return;
+
+    trackNotificationIds(persisted.items, this.seenIds, this.seenSourceIds);
+
+    this.state = {
+      items: sortByPriority(persisted.items),
+      filter: persisted.filter,
+      lastUpdated: Date.now(),
+    };
+  }
+
+  /** Visible notifications matching the active filter, priority-sorted. */
+  getVisibleNotifications(): AppNotification[] {
+    return selectVisibleNotifications(this.state.items, this.state.filter);
+  }
+
+  getUnreadCount(): number {
+    return selectUnreadCount(this.state.items);
+  }
+
+  addNotification(input: NotificationInput): void {
+    this.addNotifications([input]);
+  }
+
+  addNotifications(incoming: NotificationInput[]): void {
+    const fresh = filterFreshNotifications(
+      incoming,
+      this.seenIds,
+      this.seenSourceIds,
+    );
+    if (fresh.length === 0) return;
+
+    const normalized = fresh.map(normalizeNotificationInput);
+    trackNotificationIds(normalized, this.seenIds, this.seenSourceIds);
+
+    const merged = sortByPriority([...normalized, ...this.state.items]).slice(
+      0,
+      this.maxItems,
+    );
+
+    syncDedupeSets(merged, this.seenIds, this.seenSourceIds);
+    this.commit({ items: merged });
+  }
+
+  markAsRead(id: string): void {
+    this.updateItem(id, (item) => ({ ...item, read: true }));
+  }
+
+  markAllAsRead(): void {
+    if (!this.state.items.some((n) => !n.read && !n.dismissed)) return;
+
+    this.commit({
+      items: this.state.items.map((n) =>
+        n.dismissed ? n : { ...n, read: true },
+      ),
+    });
+  }
+
+  dismiss(id: string): void {
+    this.updateItem(id, (item) => ({ ...item, dismissed: true, read: true }));
+  }
+
+  dismissAllVisible(): void {
+    const visibleIds = new Set(
+      applyNotificationFilter(this.state.items, this.state.filter).map((n) => n.id),
+    );
+    if (visibleIds.size === 0) return;
+
+    this.commit({
+      items: this.state.items.map((n) =>
+        visibleIds.has(n.id) ? { ...n, dismissed: true, read: true } : n,
+      ),
+    });
+  }
+
+  setFilter(filter: Partial<NotificationFilter>): void {
+    this.commit({
+      filter: { ...this.state.filter, ...filter },
+    });
+  }
+
+  clearDismissed(): void {
+    const remaining = this.state.items.filter((n) => !n.dismissed);
+    if (remaining.length === this.state.items.length) return;
+
+    syncDedupeSets(remaining, this.seenIds, this.seenSourceIds);
+    this.commit({ items: remaining });
+  }
+
+  /** Test helper — reset in-memory state. */
+  reset(): void {
+    this.seenIds.clear();
+    this.seenSourceIds.clear();
+    this.hydrated = false;
+    this.state = {
+      items: [],
+      filter: DEFAULT_NOTIFICATION_FILTER,
+      lastUpdated: null,
+    };
+    this.emit();
+  }
+
+  private updateItem(
+    id: string,
+    updater: (item: AppNotification) => AppNotification,
+  ): void {
+    const index = this.state.items.findIndex((n) => n.id === id);
+    if (index === -1) return;
+
+    const items = [...this.state.items];
+    items[index] = updater(items[index]);
+    this.commit({ items });
+  }
+
+  private commit(partial: Partial<Pick<NotificationState, 'items' | 'filter'>>): void {
+    this.state = {
+      ...this.state,
+      ...partial,
+      lastUpdated: Date.now(),
+    };
+    this.persist();
+    this.emit();
+  }
+
+  private persist(): void {
+    saveNotificationState({
+      version: NOTIFICATION_STORAGE_VERSION,
+      items: this.state.items,
+      filter: this.state.filter,
+    });
+  }
+
+  private emit(): void {
+    this.listeners.forEach((cb) => cb());
+  }
+}
+
+/** Shared store instance used across the dashboard. */
+export const notificationStore = new NotificationStore();
+
+/** Imperative API for pushing notifications from hooks, contexts, or adapters. */
+export function pushNotification(input: NotificationInput): void {
+  notificationStore.hydrate();
+  notificationStore.addNotification(input);
+}
+
+export function pushNotifications(inputs: NotificationInput[]): void {
+  notificationStore.hydrate();
+  notificationStore.addNotifications(inputs);
+}

--- a/tests/components/Navbar.test.tsx
+++ b/tests/components/Navbar.test.tsx
@@ -5,6 +5,19 @@ import type { ReactNode, ReactElement } from "react";
 import Navbar from "@/components/Navbar";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 
+jest.mock("@/hooks/useNotifications", () => ({
+  useNotifications: () => ({
+    notifications: [],
+    unreadCount: 0,
+    filter: { category: "all", read: "all" },
+    markAsRead: jest.fn(),
+    markAllAsRead: jest.fn(),
+    dismiss: jest.fn(),
+    dismissAllVisible: jest.fn(),
+    setFilter: jest.fn(),
+  }),
+}));
+
 jest.mock("next/link", () => ({
   __esModule: true,
   default: ({ href, children, ...props }: { href: string; children: ReactNode }) => (

--- a/tests/notifications/filtering.test.ts
+++ b/tests/notifications/filtering.test.ts
@@ -1,0 +1,45 @@
+import { applyNotificationFilter } from '@/notifications/filtering';
+import type { AppNotification } from '@/notifications/types';
+
+function item(
+  id: string,
+  overrides: Partial<AppNotification> = {},
+): AppNotification {
+  return {
+    id,
+    category: 'transaction',
+    priority: 'normal',
+    title: id,
+    message: id,
+    timestamp: '2026-06-28T12:00:00.000Z',
+    read: false,
+    dismissed: false,
+    ...overrides,
+  };
+}
+
+describe('applyNotificationFilter', () => {
+  const items = [
+    item('a', { category: 'transaction', read: false }),
+    item('b', { category: 'governance', read: true }),
+    item('c', { category: 'reward', dismissed: true }),
+  ];
+
+  it('excludes dismissed items', () => {
+    const result = applyNotificationFilter(items, { category: 'all', read: 'all' });
+    expect(result.map((n) => n.id)).toEqual(['a', 'b']);
+  });
+
+  it('filters by category', () => {
+    const result = applyNotificationFilter(items, {
+      category: 'governance',
+      read: 'all',
+    });
+    expect(result.map((n) => n.id)).toEqual(['b']);
+  });
+
+  it('filters unread only', () => {
+    const result = applyNotificationFilter(items, { category: 'all', read: 'unread' });
+    expect(result.map((n) => n.id)).toEqual(['a']);
+  });
+});

--- a/tests/notifications/fromActivityEvent.test.ts
+++ b/tests/notifications/fromActivityEvent.test.ts
@@ -1,0 +1,41 @@
+import { notificationFromActivityEvent } from '@/notifications/adapters/fromActivityEvent';
+import type { ActivityEvent } from '@/services/events/types';
+
+function makeEvent(overrides: Partial<ActivityEvent> = {}): ActivityEvent {
+  return {
+    id: 'evt-1',
+    type: 'deposit',
+    name: 'deposit',
+    contractId: 'CVAULT',
+    ledger: 42,
+    timestamp: '2026-06-28T12:00:00.000Z',
+    topics: ['deposit'],
+    value: '100',
+    ...overrides,
+  };
+}
+
+describe('notificationFromActivityEvent', () => {
+  it('maps deposit events to transaction notifications', () => {
+    const input = notificationFromActivityEvent(makeEvent());
+    expect(input.category).toBe('transaction');
+    expect(input.priority).toBe('normal');
+    expect(input.sourceId).toBe('evt-1');
+    expect(input.id).toBe('activity:evt-1');
+    expect(input.message).toContain('ledger #42');
+  });
+
+  it('maps governance events with higher priority', () => {
+    const input = notificationFromActivityEvent(
+      makeEvent({ type: 'governance', name: 'vote' }),
+    );
+    expect(input.category).toBe('governance');
+    expect(input.priority).toBe('high');
+  });
+
+  it('maps reward events to reward category', () => {
+    const input = notificationFromActivityEvent(makeEvent({ type: 'reward' }));
+    expect(input.category).toBe('reward');
+    expect(input.priority).toBe('high');
+  });
+});

--- a/tests/notifications/normalize.test.ts
+++ b/tests/notifications/normalize.test.ts
@@ -1,0 +1,61 @@
+import {
+  filterFreshNotifications,
+  normalizeNotificationInput,
+} from '@/notifications/normalize';
+import type { NotificationInput } from '@/notifications/types';
+
+describe('normalizeNotificationInput', () => {
+  it('defaults read and dismissed to false', () => {
+    const input: NotificationInput = {
+      id: 'n-1',
+      category: 'protocol',
+      priority: 'normal',
+      title: 'Test',
+      message: 'Body',
+      timestamp: '2026-06-28T12:00:00.000Z',
+    };
+    expect(normalizeNotificationInput(input)).toEqual({
+      ...input,
+      read: false,
+      dismissed: false,
+    });
+  });
+});
+
+describe('filterFreshNotifications', () => {
+  const seenIds = new Set(['a']);
+  const seenSourceIds = new Set(['src-1']);
+
+  it('excludes duplicates by id or sourceId', () => {
+    const incoming: NotificationInput[] = [
+      {
+        id: 'a',
+        category: 'transaction',
+        priority: 'normal',
+        title: 'A',
+        message: 'A',
+        timestamp: '2026-06-28T12:00:00.000Z',
+      },
+      {
+        id: 'b',
+        sourceId: 'src-1',
+        category: 'transaction',
+        priority: 'normal',
+        title: 'B',
+        message: 'B',
+        timestamp: '2026-06-28T12:00:00.000Z',
+      },
+      {
+        id: 'c',
+        category: 'reward',
+        priority: 'high',
+        title: 'C',
+        message: 'C',
+        timestamp: '2026-06-28T12:00:00.000Z',
+      },
+    ];
+
+    expect(filterFreshNotifications(incoming, seenIds, seenSourceIds)).toHaveLength(1);
+    expect(filterFreshNotifications(incoming, seenIds, seenSourceIds)[0].id).toBe('c');
+  });
+});

--- a/tests/notifications/notificationStore.test.ts
+++ b/tests/notifications/notificationStore.test.ts
@@ -1,0 +1,141 @@
+import { NotificationStore } from '@/store/notificationStore';
+import type { NotificationInput } from '@/notifications/types';
+import {
+  clearNotificationStorage,
+  loadNotificationState,
+} from '@/notifications/persistence';
+
+function makeNotification(
+  id: string,
+  overrides: Partial<NotificationInput> = {},
+): NotificationInput {
+  return {
+    id,
+    category: 'transaction',
+    priority: 'normal',
+    title: `Notification ${id}`,
+    message: `Message for ${id}`,
+    timestamp: '2026-06-28T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('NotificationStore', () => {
+  beforeEach(() => {
+    clearNotificationStorage();
+    localStorage.clear();
+  });
+
+  it('starts empty with default filter', () => {
+    const store = new NotificationStore();
+    expect(store.getSnapshot().items).toEqual([]);
+    expect(store.getVisibleNotifications()).toEqual([]);
+    expect(store.getUnreadCount()).toBe(0);
+  });
+
+  it('orders by priority then timestamp', () => {
+    const store = new NotificationStore();
+    store.addNotifications([
+      makeNotification('low', {
+        priority: 'low',
+        timestamp: '2026-06-28T14:00:00.000Z',
+      }),
+      makeNotification('critical', {
+        priority: 'critical',
+        timestamp: '2026-06-28T10:00:00.000Z',
+      }),
+      makeNotification('high', {
+        priority: 'high',
+        timestamp: '2026-06-28T13:00:00.000Z',
+      }),
+    ]);
+
+    expect(store.getVisibleNotifications().map((n) => n.id)).toEqual([
+      'critical',
+      'high',
+      'low',
+    ]);
+  });
+
+  it('ignores duplicate ids and sourceIds', () => {
+    const store = new NotificationStore();
+    store.addNotification(makeNotification('a', { sourceId: 'evt-1' }));
+    store.addNotification(makeNotification('a'));
+    store.addNotification(makeNotification('b', { sourceId: 'evt-1' }));
+    expect(store.getSnapshot().items).toHaveLength(1);
+  });
+
+  it('tracks read and unread counts', () => {
+    const store = new NotificationStore();
+    store.addNotifications([makeNotification('a'), makeNotification('b')]);
+    expect(store.getUnreadCount()).toBe(2);
+
+    store.markAsRead('a');
+    expect(store.getUnreadCount()).toBe(1);
+
+    store.markAllAsRead();
+    expect(store.getUnreadCount()).toBe(0);
+  });
+
+  it('dismisses notifications and hides them from visible list', () => {
+    const store = new NotificationStore();
+    store.addNotifications([makeNotification('a'), makeNotification('b')]);
+    store.dismiss('a');
+
+    const visible = store.getVisibleNotifications();
+    expect(visible).toHaveLength(1);
+    expect(visible[0].id).toBe('b');
+    expect(store.getSnapshot().items.find((n) => n.id === 'a')?.dismissed).toBe(true);
+  });
+
+  it('filters by category and read state', () => {
+    const store = new NotificationStore();
+    store.addNotifications([
+      makeNotification('tx', { category: 'transaction' }),
+      makeNotification('gov', { category: 'governance', priority: 'high' }),
+    ]);
+    store.markAsRead('tx');
+
+    store.setFilter({ category: 'governance', read: 'all' });
+    expect(store.getVisibleNotifications().map((n) => n.id)).toEqual(['gov']);
+
+    store.setFilter({ category: 'all', read: 'unread' });
+    expect(store.getVisibleNotifications().map((n) => n.id)).toEqual(['gov']);
+
+    store.setFilter({ category: 'all', read: 'read' });
+    expect(store.getVisibleNotifications().map((n) => n.id)).toEqual(['tx']);
+  });
+
+  it('persists read/unread state to localStorage', () => {
+    const store = new NotificationStore();
+    store.addNotification(makeNotification('persist-me'));
+    store.markAsRead('persist-me');
+
+    const persisted = loadNotificationState();
+    expect(persisted?.items.find((n) => n.id === 'persist-me')?.read).toBe(true);
+
+    const reloaded = new NotificationStore();
+    reloaded.hydrate();
+    expect(reloaded.getSnapshot().items.find((n) => n.id === 'persist-me')?.read).toBe(
+      true,
+    );
+  });
+
+  it('notifies subscribers on changes', () => {
+    const store = new NotificationStore();
+    const listener = jest.fn();
+    store.subscribe(listener);
+    store.addNotification(makeNotification('x'));
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('caps retained notifications', () => {
+    const store = new NotificationStore(2);
+    store.addNotifications([
+      makeNotification('a'),
+      makeNotification('b'),
+      makeNotification('c'),
+    ]);
+    expect(store.getSnapshot().items).toHaveLength(2);
+  });
+});

--- a/tests/notifications/sharedStreamLifecycle.test.ts
+++ b/tests/notifications/sharedStreamLifecycle.test.ts
@@ -1,0 +1,58 @@
+import {
+  resetSharedEventStreamForTests,
+  subscribeSharedEventStream,
+} from '@/services/events/sharedStreamLifecycle';
+import type { EventSubscriptionService } from '@/services/events';
+
+function createMockService(): EventSubscriptionService & {
+  start: jest.Mock;
+  stop: jest.Mock;
+  onEvent: jest.Mock;
+  onStatusChange: jest.Mock;
+} {
+  const eventHandlers = new Set<(event: unknown) => void>();
+  const statusHandlers = new Set<(status: unknown) => void>();
+
+  return {
+    start: jest.fn(),
+    stop: jest.fn(),
+    onEvent: jest.fn((handler) => {
+      eventHandlers.add(handler);
+      return () => eventHandlers.delete(handler);
+    }),
+    onStatusChange: jest.fn((handler) => {
+      statusHandlers.add(handler);
+      return () => statusHandlers.delete(handler);
+    }),
+  } as unknown as EventSubscriptionService & {
+    start: jest.Mock;
+    stop: jest.Mock;
+    onEvent: jest.Mock;
+    onStatusChange: jest.Mock;
+  };
+}
+
+describe('subscribeSharedEventStream', () => {
+  beforeEach(() => {
+    resetSharedEventStreamForTests();
+  });
+
+  it('starts the service on first subscriber and stops after last release', () => {
+    const service = createMockService();
+    const releaseA = subscribeSharedEventStream(service, {
+      onEvent: jest.fn(),
+    });
+    expect(service.start).toHaveBeenCalledTimes(1);
+
+    const releaseB = subscribeSharedEventStream(service, {
+      onEvent: jest.fn(),
+    });
+    expect(service.start).toHaveBeenCalledTimes(1);
+
+    releaseA();
+    expect(service.stop).not.toHaveBeenCalled();
+
+    releaseB();
+    expect(service.stop).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Implements a centralized **Notification Center** (#268) for protocol alerts, transaction updates, governance events, and reward notifications. Users get a persistent, filterable inbox in the Navbar without relying on push, email, or backend messaging.

## Architecture

- **`src/notifications/`** — Schema, selectors, filtering, prioritization, persistence, and activity-event adapter
- **`src/store/notificationStore.ts`** — Observable queue (framework-agnostic, `useSyncExternalStore`-ready) with deduplication and a 100-item cap
- **`src/hooks/useNotifications.ts`** — React hook exposing filtered list, unread count, and lifecycle actions
- **`src/components/notifications/`** — Navbar panel (bell icon, filters, read/dismiss actions)
- **`src/services/events/sharedStreamLifecycle.ts`** — Shared refcount for the event stream so the notification bridge and activity feed do not stop each other on unmount

Toasts via Sonner (`src/utils/notifications.ts`) remain unchanged for immediate action feedback.

## Features

- **Categories:** `protocol`, `transaction`, `governance`, `reward`
- **Priorities:** `critical` → `high` → `normal` → `low`, then newest first
- **Persistence:** Read/unread and dismissed state in `localStorage` (`axionvera:notifications:v1`)
- **Filtering:** By category and read status in the panel UI
- **Live ingest:** Bridge from Soroban protocol events (#215) via `activityBridge.ts`

## Prioritization logic

Notifications sort by priority rank, then by ISO timestamp (newest first). Duplicate ingestion is prevented by `id` and optional `sourceId`.

## Persistence strategy

State hydrates once on mount. Every mutation (add, read, dismiss, filter change) writes to localStorage with a version field for future migrations (#252).

## Testing

`tests/notifications/` — **18 tests** covering:

- Priority ordering and queue cap
- Read/unread and dismissal lifecycle
- Category/read filtering
- localStorage persistence
- Activity event → notification mapping
- Shared event-stream refcount behavior

Run: `npm test -- tests/notifications`

Note: `npm run lint` fails on pre-existing errors in `RouteGuard.tsx` and `performance.ts`. Notification files pass lint in isolation.


## Out of scope (per issue)

- Push notifications, email delivery, backend messaging

## Review focus

1. Store/hook separation and selector derivations from snapshot
2. Shared event-stream lifecycle vs. duplicate `stop()` on unmount
3. Persistence and dedupe behavior under cap
4. UI integration in Navbar without breaking existing wallet flow

Closes #268