### PR TITLE
feat(policy): add complete policy management system

### DIFF
--- a/src/policy/engine.test.ts
+++ b/src/policy/engine.test.ts
@@ -1,0 +1,173 @@
+import {
+  PolicyEngine,
+  AllowAllPolicy,
+  DenyAllPolicy,
+  OperationWhitelistPolicy,
+  ActorRestrictionPolicy,
+  TimeWindowPolicy
+} from './index';
+import type { PolicyContext } from './types';
+
+describe('PolicyEngine', () => {
+  let engine: PolicyEngine;
+  const mockContext: PolicyContext = {
+    timestamp: Date.now(),
+    actor: 'test-actor',
+    operation: 'test-operation',
+    metadata: {}
+  };
+
+  beforeEach(() => {
+    engine = new PolicyEngine();
+  });
+
+  describe('policy management', () => {
+    test('adds and retrieves a policy', () => {
+      const policy = new AllowAllPolicy();
+      engine.addPolicy(policy);
+
+      expect(engine.getPolicy(policy.id)).toBe(policy);
+      expect(engine.getAllPolicies()).toHaveLength(1);
+    });
+
+    test('removes a policy', () => {
+      const policy = new AllowAllPolicy();
+      engine.addPolicy(policy);
+
+      const removed = engine.removePolicy(policy.id);
+      expect(removed).toBe(true);
+      expect(engine.getPolicy(policy.id)).toBeUndefined();
+    });
+  });
+
+  describe('evaluation', () => {
+    test('allow all policy evaluates to allow', async () => {
+      engine.addPolicy(new AllowAllPolicy());
+      const result = await engine.evaluate(mockContext);
+      expect(result.result).toBe('allow');
+      expect(result.violations).toHaveLength(0);
+    });
+
+    test('deny all policy evaluates to deny', async () => {
+      engine.addPolicy(new DenyAllPolicy());
+      const result = await engine.evaluate(mockContext);
+      expect(result.result).toBe('deny');
+      expect(result.violations).toHaveLength(1);
+    });
+
+    test('operation whitelist policy allows whitelisted operations', async () => {
+      const policy = new OperationWhitelistPolicy({
+        id: 'whitelist-1',
+        name: 'Test Whitelist',
+        allowedOperations: ['allowed-op']
+      });
+      engine.addPolicy(policy);
+
+      const allowedContext: PolicyContext = {
+        ...mockContext,
+        operation: 'allowed-op'
+      };
+      const allowedResult = await engine.evaluate(allowedContext);
+      expect(allowedResult.result).toBe('allow');
+
+      const deniedResult = await engine.evaluate(mockContext);
+      expect(deniedResult.result).toBe('deny');
+    });
+
+    test('actor restriction policy allows specified actors', async () => {
+      const policy = new ActorRestrictionPolicy({
+        id: 'actor-restriction',
+        name: 'Test Actor Restriction',
+        allowedActors: ['allowed-actor']
+      });
+      engine.addPolicy(policy);
+
+      const allowedContext: PolicyContext = {
+        ...mockContext,
+        actor: 'allowed-actor'
+      };
+      const allowedResult = await engine.evaluate(allowedContext);
+      expect(allowedResult.result).toBe('allow');
+
+      const deniedResult = await engine.evaluate(mockContext);
+      expect(deniedResult.result).toBe('deny');
+    });
+
+    test('time window policy allows operations during window', async () => {
+      const now = new Date();
+      const currentHour = now.getHours();
+      
+      const policy = new TimeWindowPolicy({
+        id: 'time-window',
+        name: 'Test Time Window',
+        startHour: currentHour,
+        endHour: currentHour + 1
+      });
+      engine.addPolicy(policy);
+
+      const result = await engine.evaluate(mockContext);
+      expect(result.result).toBe('allow');
+    });
+
+    test('multiple policies with one deny results in deny', async () => {
+      engine.addPolicy(new AllowAllPolicy());
+      engine.addPolicy(new DenyAllPolicy());
+
+      const result = await engine.evaluate(mockContext);
+      expect(result.result).toBe('deny');
+    });
+
+    test('disabled policies are not evaluated', async () => {
+      const denyPolicy = new DenyAllPolicy();
+      denyPolicy.enabled = false;
+      engine.addPolicy(denyPolicy);
+
+      const result = await engine.evaluate(mockContext);
+      expect(result.result).toBe('allow');
+    });
+  });
+
+  describe('events', () => {
+    test('emits policy added event', () => {
+      const handler = jest.fn();
+      engine.subscribe(handler);
+
+      const policy = new AllowAllPolicy();
+      engine.addPolicy(policy);
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'policy.added'
+        })
+      );
+    });
+
+    test('emits policy evaluated event', async () => {
+      const handler = jest.fn();
+      engine.subscribe(handler);
+      engine.addPolicy(new AllowAllPolicy());
+
+      await engine.evaluate(mockContext);
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'policy.evaluated'
+        })
+      );
+    });
+
+    test('unsubscribes handler', () => {
+      const handler = jest.fn();
+      const unsubscribe = engine.subscribe(handler);
+      
+      const policy = new AllowAllPolicy();
+      engine.addPolicy(policy);
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      unsubscribe();
+      
+      engine.addPolicy(new DenyAllPolicy());
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/policy/engine.ts
+++ b/src/policy/engine.ts
@@ -1,0 +1,96 @@
+import type {
+  Policy,
+  PolicyContext,
+  PolicyEvaluationResponse,
+  PolicyEvaluationResult,
+  PolicyEvent,
+  PolicyEventHandler,
+  PolicyViolation
+} from './types';
+
+export class PolicyEngine {
+  private policies: Map<string, Policy> = new Map();
+  private eventHandlers: Set<PolicyEventHandler> = new Set();
+
+  addPolicy(policy: Policy): void {
+    this.policies.set(policy.id, policy);
+    this.emitEvent({
+      type: 'policy.added',
+      timestamp: Date.now(),
+      data: { policyId: policy.id }
+    });
+  }
+
+  removePolicy(policyId: string): boolean {
+    const existed = this.policies.delete(policyId);
+    if (existed) {
+      this.emitEvent({
+        type: 'policy.removed',
+        timestamp: Date.now(),
+        data: { policyId }
+      });
+    }
+    return existed;
+  }
+
+  getPolicy(policyId: string): Policy | undefined {
+    return this.policies.get(policyId);
+  }
+
+  getAllPolicies(): Policy[] {
+    return Array.from(this.policies.values());
+  }
+
+  async evaluate(context: PolicyContext): Promise<PolicyEvaluationResponse> {
+    const enabledPolicies = this.getAllPolicies().filter(p => p.enabled);
+    const allViolations: PolicyViolation[] = [];
+    let finalResult: PolicyEvaluationResult = PolicyEvaluationResult.ALLOW;
+
+    for (const policy of enabledPolicies) {
+      const response = await policy.evaluate(context);
+      
+      allViolations.push(...response.violations);
+      
+      if (response.result === PolicyEvaluationResult.DENY) {
+        finalResult = PolicyEvaluationResult.DENY;
+      } else if (response.result === PolicyEvaluationResult.WARN && finalResult === PolicyEvaluationResult.ALLOW) {
+        finalResult = PolicyEvaluationResult.WARN;
+      }
+    }
+
+    const evaluationResponse: PolicyEvaluationResponse = {
+      result: finalResult,
+      violations: allViolations,
+      evaluatedAt: Date.now(),
+      policyCount: enabledPolicies.length
+    };
+
+    this.emitEvent({
+      type: 'policy.evaluated',
+      timestamp: Date.now(),
+      data: {
+        context,
+        response: evaluationResponse
+      }
+    });
+
+    return evaluationResponse;
+  }
+
+  subscribe(handler: PolicyEventHandler): () => void {
+    this.eventHandlers.add(handler);
+    return () => {
+      this.eventHandlers.delete(handler);
+    };
+  }
+
+  private emitEvent(event: PolicyEvent): void {
+    for (const handler of this.eventHandlers) {
+      try {
+        void handler(event);
+      } catch (error) {
+        console.error('Policy event handler error:', error);
+      }
+    }
+  }
+}

--- a/src/policy/index.ts
+++ b/src/policy/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './policies';
+export * from './engine';

--- a/src/policy/policies.ts
+++ b/src/policy/policies.ts
@@ -1,0 +1,243 @@
+import type {
+  Policy,
+  PolicyContext,
+  PolicyEvaluationResponse,
+  PolicyEvaluationResult,
+  PolicyViolation
+} from './types';
+
+export abstract class BasePolicy implements Policy {
+  readonly id: string;
+  readonly name: string;
+  readonly description?: string;
+  readonly version: string;
+  enabled: boolean;
+
+  constructor(params: {
+    id: string;
+    name: string;
+    description?: string;
+    version: string;
+    enabled?: boolean;
+  }) {
+    this.id = params.id;
+    this.name = params.name;
+    this.description = params.description;
+    this.version = params.version;
+    this.enabled = params.enabled ?? true;
+  }
+
+  abstract evaluate(context: PolicyContext): Promise<PolicyEvaluationResponse>;
+}
+
+export class AllowAllPolicy extends BasePolicy {
+  constructor() {
+    super({
+      id: 'allow-all',
+      name: 'Allow All',
+      description: 'Allows all operations',
+      version: '1.0.0'
+    });
+  }
+
+  async evaluate(context: PolicyContext): Promise<PolicyEvaluationResponse> {
+    return {
+      result: PolicyEvaluationResult.ALLOW,
+      violations: [],
+      evaluatedAt: Date.now(),
+      policyCount: 1
+    };
+  }
+}
+
+export class DenyAllPolicy extends BasePolicy {
+  constructor() {
+    super({
+      id: 'deny-all',
+      name: 'Deny All',
+      description: 'Denies all operations',
+      version: '1.0.0'
+    });
+  }
+
+  async evaluate(context: PolicyContext): Promise<PolicyEvaluationResponse> {
+    const violation: PolicyViolation = {
+      policyId: this.id,
+      message: 'All operations are denied by this policy',
+      severity: 'error'
+    };
+
+    return {
+      result: PolicyEvaluationResult.DENY,
+      violations: [violation],
+      evaluatedAt: Date.now(),
+      policyCount: 1
+    };
+  }
+}
+
+export class OperationWhitelistPolicy extends BasePolicy {
+  private allowedOperations: Set<string>;
+
+  constructor(params: {
+    id: string;
+    name: string;
+    description?: string;
+    allowedOperations: string[];
+    enabled?: boolean;
+  }) {
+    super({
+      id: params.id,
+      name: params.name,
+      description: params.description,
+      version: '1.0.0',
+      enabled: params.enabled
+    });
+    this.allowedOperations = new Set(params.allowedOperations);
+  }
+
+  async evaluate(context: PolicyContext): Promise<PolicyEvaluationResponse> {
+    if (!this.enabled) {
+      return {
+        result: PolicyEvaluationResult.ALLOW,
+        violations: [],
+        evaluatedAt: Date.now(),
+        policyCount: 1
+      };
+    }
+
+    if (this.allowedOperations.has(context.operation)) {
+      return {
+        result: PolicyEvaluationResult.ALLOW,
+        violations: [],
+        evaluatedAt: Date.now(),
+        policyCount: 1
+      };
+    }
+
+    const violation: PolicyViolation = {
+      policyId: this.id,
+      message: `Operation "${context.operation}" is not in the whitelist`,
+      severity: 'error'
+    };
+
+    return {
+      result: PolicyEvaluationResult.DENY,
+      violations: [violation],
+      evaluatedAt: Date.now(),
+      policyCount: 1
+    };
+  }
+}
+
+export class ActorRestrictionPolicy extends BasePolicy {
+  private allowedActors: Set<string>;
+
+  constructor(params: {
+    id: string;
+    name: string;
+    description?: string;
+    allowedActors: string[];
+    enabled?: boolean;
+  }) {
+    super({
+      id: params.id,
+      name: params.name,
+      description: params.description,
+      version: '1.0.0',
+      enabled: params.enabled
+    });
+    this.allowedActors = new Set(params.allowedActors);
+  }
+
+  async evaluate(context: PolicyContext): Promise<PolicyEvaluationResponse> {
+    if (!this.enabled) {
+      return {
+        result: PolicyEvaluationResult.ALLOW,
+        violations: [],
+        evaluatedAt: Date.now(),
+        policyCount: 1
+      };
+    }
+
+    if (this.allowedActors.has(context.actor)) {
+      return {
+        result: PolicyEvaluationResult.ALLOW,
+        violations: [],
+        evaluatedAt: Date.now(),
+        policyCount: 1
+      };
+    }
+
+    const violation: PolicyViolation = {
+      policyId: this.id,
+      message: `Actor "${context.actor}" is not allowed to perform this operation`,
+      severity: 'error'
+    };
+
+    return {
+      result: PolicyEvaluationResult.DENY,
+      violations: [violation],
+      evaluatedAt: Date.now(),
+      policyCount: 1
+    };
+  }
+}
+
+export class TimeWindowPolicy extends BasePolicy {
+  private startHour: number;
+  private endHour: number;
+
+  constructor(params: {
+    id: string;
+    name: string;
+    description?: string;
+    startHour: number;
+    endHour: number;
+    enabled?: boolean;
+  }) {
+    super({
+      id: params.id,
+      name: params.name,
+      description: params.description,
+      version: '1.0.0',
+      enabled: params.enabled
+    });
+    this.startHour = params.startHour;
+    this.endHour = params.endHour;
+  }
+
+  async evaluate(context: PolicyContext): Promise<PolicyEvaluationResponse> {
+    if (!this.enabled) {
+      return {
+        result: PolicyEvaluationResult.ALLOW,
+        violations: [],
+        evaluatedAt: Date.now(),
+        policyCount: 1
+      };
+    }
+
+    const currentHour = new Date(context.timestamp).getHours();
+    if (currentHour >= this.startHour && currentHour < this.endHour) {
+      return {
+        result: PolicyEvaluationResult.ALLOW,
+        violations: [],
+        evaluatedAt: Date.now(),
+        policyCount: 1
+      };
+    }
+
+    const violation: PolicyViolation = {
+      policyId: this.id,
+      message: `Operation not allowed outside of ${this.startHour}:00 - ${this.endHour}:00`,
+      severity: 'error'
+    };
+
+    return {
+      result: PolicyEvaluationResult.DENY,
+      violations: [violation],
+      evaluatedAt: Date.now(),
+      policyCount: 1
+    };
+  }
+}

--- a/src/policy/types.ts
+++ b/src/policy/types.ts
@@ -1,0 +1,47 @@
+export enum PolicyEvaluationResult {
+  ALLOW = 'allow',
+  DENY = 'deny',
+  WARN = 'warn'
+}
+
+export interface PolicyContext {
+  timestamp: number;
+  actor: string;
+  operation: string;
+  metadata?: Record<string, unknown>;
+  state?: Record<string, unknown>;
+}
+
+export interface PolicyViolation {
+  policyId: string;
+  message: string;
+  severity: 'error' | 'warning';
+}
+
+export interface PolicyEvaluationResponse {
+  result: PolicyEvaluationResult;
+  violations: PolicyViolation[];
+  evaluatedAt: number;
+  policyCount: number;
+}
+
+export interface Policy {
+  id: string;
+  name: string;
+  description?: string;
+  version: string;
+  enabled: boolean;
+  evaluate(context: PolicyContext): Promise<PolicyEvaluationResponse>;
+}
+
+export interface PolicyEvaluator {
+  evaluate(policy: Policy, context: PolicyContext): Promise<PolicyEvaluationResponse>;
+}
+
+export interface PolicyEvent {
+  type: 'policy.evaluated' | 'policy.added' | 'policy.removed' | 'policy.updated';
+  timestamp: number;
+  data: unknown;
+}
+
+export type PolicyEventHandler = (event: PolicyEvent) => void | Promise<void>;


### PR DESCRIPTION
closes #267
Add TypeScript type definitions for all policy-related entities, implement a reusable policy engine with event support, provide an abstract base policy class for custom policy development, include common pre-built policy implementations, and add comprehensive unit test coverage for the entire system.