### PR TITLE
feat: add collaborative dashboard editing framework

### DIFF
--- a/docs/collaboration.md
+++ b/docs/collaboration.md
@@ -1,0 +1,83 @@
+# Collaboration Framework
+
+## Overview
+
+The collaboration framework provides the foundation for collaborative dashboard editing by introducing a synchronization layer, conflict resolution strategy, and user presence management. It is designed to work alongside the existing workspace management system without modifying its core behavior.
+
+This implementation focuses on the client-side collaboration architecture. Backend networking and authentication are intentionally out of scope.
+
+## Architecture
+
+The collaboration framework consists of the following components:
+
+### SyncManager
+
+`SyncManager` coordinates collaboration events.
+
+Responsibilities include:
+
+* Publishing workspace operations
+* Notifying subscribed listeners
+* Providing access to the current workspace snapshot
+* Exposing the active workspace
+
+### PresenceManager
+
+`PresenceManager` tracks users participating in a collaboration session.
+
+Supported operations include:
+
+* User join
+* User leave
+* Heartbeat updates
+* Retrieving active collaborators
+
+### ConflictResolver
+
+`ConflictResolver` provides deterministic conflict handling using a **Last Write Wins (LWW)** strategy.
+
+When multiple operations modify the same workspace, the operation with the newest timestamp is selected as the authoritative update.
+
+### Collaboration Protocol
+
+The collaboration protocol defines a shared message format for workspace operations.
+
+Each operation records:
+
+* Workspace identifier
+* User identifier
+* Operation type
+* Timestamp
+
+This structure provides a consistent representation for synchronization events.
+
+## Synchronization Lifecycle
+
+A typical collaboration flow follows these steps:
+
+1. A user performs a workspace operation.
+2. The operation is published through `SyncManager`.
+3. Subscribers receive the operation.
+4. If conflicting operations exist, `ConflictResolver` determines the authoritative update.
+5. Workspace state remains synchronized across participants.
+
+## Testing
+
+The collaboration framework includes dedicated unit tests covering:
+
+* Presence management
+* Conflict resolution
+* Synchronization event publishing
+* Workspace snapshot access
+
+These tests validate the core collaboration workflow independently from the rest of the application.
+
+## Future Enhancements
+
+Possible future improvements include:
+
+* Real-time transport using WebSocket or Server-Sent Events
+* Operational Transformation (OT) or CRDT-based conflict resolution
+* Shared cursor and live editing indicators
+* Workspace locking and edit permissions
+* Persistent collaboration sessions

--- a/src/collaboration/conflictResolver.ts
+++ b/src/collaboration/conflictResolver.ts
@@ -1,0 +1,10 @@
+import type { WorkspaceOperation } from "./types";
+
+export class ConflictResolver {
+  resolve(
+    local: WorkspaceOperation,
+    remote: WorkspaceOperation,
+  ): WorkspaceOperation {
+    return local.timestamp >= remote.timestamp ? local : remote;
+  }
+}

--- a/src/collaboration/index.ts
+++ b/src/collaboration/index.ts
@@ -1,0 +1,5 @@
+export * from "./types";
+export * from "./protocol";
+export * from "./presence";
+export * from "./conflictResolver";
+export * from "./syncManager";

--- a/src/collaboration/presence.ts
+++ b/src/collaboration/presence.ts
@@ -1,0 +1,46 @@
+import type { CollaborationUser } from "./types";
+
+export class PresenceManager {
+  private readonly users = new Map<string, CollaborationUser>();
+
+  join(user: CollaborationUser): void {
+    this.users.set(user.id, {
+      ...user,
+      active: true,
+      lastSeen: Date.now(),
+    });
+  }
+
+  leave(userId: string): void {
+    const user = this.users.get(userId);
+    if (!user) return;
+
+    this.users.set(userId, {
+      ...user,
+      active: false,
+      lastSeen: Date.now(),
+    });
+  }
+
+  heartbeat(userId: string): void {
+    const user = this.users.get(userId);
+    if (!user) return;
+
+    this.users.set(userId, {
+      ...user,
+      lastSeen: Date.now(),
+    });
+  }
+
+  getUsers(): CollaborationUser[] {
+    return Array.from(this.users.values());
+  }
+
+  getActiveUsers(): CollaborationUser[] {
+    return this.getUsers().filter((user) => user.active);
+  }
+
+  clear(): void {
+    this.users.clear();
+  }
+}

--- a/src/collaboration/protocol.ts
+++ b/src/collaboration/protocol.ts
@@ -1,0 +1,15 @@
+import type { WorkspaceOperation } from "./types";
+
+export interface CollaborationMessage {
+  type: "workspace-operation";
+  payload: WorkspaceOperation;
+}
+
+export function createMessage(
+  operation: WorkspaceOperation,
+): CollaborationMessage {
+  return {
+    type: "workspace-operation",
+    payload: operation,
+  };
+}

--- a/src/collaboration/syncManager.ts
+++ b/src/collaboration/syncManager.ts
@@ -1,0 +1,58 @@
+import type { WorkspaceStore } from "../workspaces/store";
+import { PresenceManager } from "./presence";
+import { ConflictResolver } from "./conflictResolver";
+import type {
+  CollaborationSnapshot,
+  WorkspaceOperation,
+} from "./types";
+
+type SyncListener = (operation: WorkspaceOperation) => void;
+
+export class SyncManager {
+  private readonly listeners = new Set<SyncListener>();
+  private readonly operations: WorkspaceOperation[] = [];
+  private readonly presence = new PresenceManager();
+  private readonly conflictResolver = new ConflictResolver();
+
+  constructor(private readonly workspaceStore: WorkspaceStore) {}
+
+  subscribe(listener: SyncListener): () => void {
+    this.listeners.add(listener);
+
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  publish(operation: WorkspaceOperation): void {
+    this.operations.push(operation);
+
+    this.listeners.forEach((listener) => listener(operation));
+  }
+
+  resolveConflict(
+    local: WorkspaceOperation,
+    remote: WorkspaceOperation,
+  ): WorkspaceOperation {
+    return this.conflictResolver.resolve(local, remote);
+  }
+
+  getPresenceManager(): PresenceManager {
+    return this.presence;
+  }
+
+  getSnapshot(): CollaborationSnapshot {
+    return {
+      users: this.presence.getUsers(),
+      operations: [...this.operations],
+    };
+  }
+
+  getWorkspaceSnapshot() {
+    return this.workspaceStore.getSnapshot();
+  }
+
+  getActiveWorkspace() {
+    return this.workspaceStore.getActiveWorkspace();
+  }
+}

--- a/src/collaboration/types.ts
+++ b/src/collaboration/types.ts
@@ -1,0 +1,24 @@
+export type CollaborationOperation =
+  | "create"
+  | "update"
+  | "delete"
+  | "switch";
+
+export interface CollaborationUser {
+  id: string;
+  name: string;
+  active: boolean;
+  lastSeen: number;
+}
+
+export interface WorkspaceOperation {
+  workspaceId: string;
+  userId: string;
+  operation: CollaborationOperation;
+  timestamp: number;
+}
+
+export interface CollaborationSnapshot {
+  users: CollaborationUser[];
+  operations: WorkspaceOperation[];
+}

--- a/tests/collaboration/conflictResolver.test.ts
+++ b/tests/collaboration/conflictResolver.test.ts
@@ -1,0 +1,41 @@
+import { ConflictResolver } from "../../src/collaboration/conflictResolver";
+
+describe("ConflictResolver", () => {
+  const resolver = new ConflictResolver();
+
+  it("returns the newest operation", () => {
+    const local = {
+      workspaceId: "1",
+      userId: "alice",
+      operation: "update" as const,
+      timestamp: 10,
+    };
+
+    const remote = {
+      workspaceId: "1",
+      userId: "bob",
+      operation: "update" as const,
+      timestamp: 20,
+    };
+
+    expect(resolver.resolve(local, remote)).toEqual(remote);
+  });
+
+  it("keeps local when timestamps are equal", () => {
+    const local = {
+      workspaceId: "1",
+      userId: "alice",
+      operation: "update" as const,
+      timestamp: 20,
+    };
+
+    const remote = {
+      workspaceId: "1",
+      userId: "bob",
+      operation: "update" as const,
+      timestamp: 20,
+    };
+
+    expect(resolver.resolve(local, remote)).toEqual(local);
+  });
+});

--- a/tests/collaboration/presence.test.ts
+++ b/tests/collaboration/presence.test.ts
@@ -1,0 +1,47 @@
+import { PresenceManager } from "../../src/collaboration/presence";
+
+describe("PresenceManager", () => {
+  let manager: PresenceManager;
+
+  beforeEach(() => {
+    manager = new PresenceManager();
+  });
+
+  it("adds a user when joining", () => {
+    manager.join({
+      id: "user-1",
+      name: "Alice",
+      active: true,
+      lastSeen: 0,
+    });
+
+    expect(manager.getUsers()).toHaveLength(1);
+    expect(manager.getActiveUsers()).toHaveLength(1);
+  });
+
+  it("marks a user inactive when leaving", () => {
+    manager.join({
+      id: "user-1",
+      name: "Alice",
+      active: true,
+      lastSeen: 0,
+    });
+
+    manager.leave("user-1");
+
+    expect(manager.getActiveUsers()).toHaveLength(0);
+  });
+
+  it("clears all users", () => {
+    manager.join({
+      id: "user-1",
+      name: "Alice",
+      active: true,
+      lastSeen: 0,
+    });
+
+    manager.clear();
+
+    expect(manager.getUsers()).toHaveLength(0);
+  });
+});

--- a/tests/collaboration/syncManager.test.ts
+++ b/tests/collaboration/syncManager.test.ts
@@ -1,0 +1,33 @@
+import { SyncManager } from "../../src/collaboration/syncManager";
+import { WorkspaceStore } from "../../src/workspaces/store";
+
+describe("SyncManager", () => {
+  let manager: SyncManager;
+
+  beforeEach(() => {
+    manager = new SyncManager(new WorkspaceStore());
+  });
+
+  it("publishes workspace operations", () => {
+    const listener = jest.fn();
+
+    manager.subscribe(listener);
+
+    manager.publish({
+      workspaceId: "workspace-1",
+      userId: "alice",
+      operation: "update",
+      timestamp: Date.now(),
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns workspace snapshot", () => {
+    expect(manager.getWorkspaceSnapshot()).toBeDefined();
+  });
+
+  it("returns active workspace", () => {
+    expect(manager.getActiveWorkspace()).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #284

### What changed

* Added a collaboration framework under `src/collaboration`
* Implemented collaboration protocol and shared operation types
* Added `PresenceManager` for participant tracking
* Added `ConflictResolver` using a Last Write Wins strategy
* Added `SyncManager` to coordinate collaboration events
* Added unit tests covering presence, conflict resolution, and synchronization
* Added collaboration architecture documentation

### Testing

```bash
npx jest tests/collaboration --verbose
```

Results:

* 3 test suites passed
* 8 tests passed

### Notes

This PR introduces the client-side collaboration framework. Authentication, networking, and backend synchronization remain out of scope, consistent with the issue requirements.
